### PR TITLE
Better errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -224,6 +224,30 @@ If an action responses an error on a remote node, the transporter will send back
 broker.call("account.deposit").catch(err => console.log(err.stack)); 
 ```
 
+## Type property in custom error
+The `CustomError` class renamed to `MoleculerError`. It got a `type` new property. You can store here a custom error type. E.g if you have a Validation error sometimes you don't enough the name & code. With `type` the client can handle the cause of error programmatically. 
+
+**Example**
+```js
+const ERR_MISSING_ID = "ERR_MISSING_ID";
+const ERR_ENTITY_NOT_FOUND = "ERR_ENTITY_NOT_FOUND";
+
+broker.createService({
+    actions: {
+        get(ctx) {
+            if (ctx.params.id) {
+                const entity = this.searchEntity(ctx.params.id);
+                if (entity)
+                    return entity;
+                else
+                    return Promise.reject(new ValidationError("Not found entity!", ERR_ENTITY_NOT_FOUND));
+            } else
+                return Promise.reject(new ValidationError("Please set the ID field!", ERR_MISSING_ID));
+        }
+    }
+});
+
+```
 
 --------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -299,7 +299,7 @@ broker.createService({
             if (meta.loggedInUser && meta.loggedInUser.roles.indexOf("admin") !== -1)
                 return Promise.resolve(...);
             else
-                throw new CustomError("Access denied!");
+                throw new MoleculerError("Access denied!");
         }
     }
 });

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,13 +3,13 @@
 ## v0.8.x
 - [x] direct remote call to a specified node (for monitoring every node)
 - [ ] multi broker.call (array params & returns with array result )
+- [x] Official services ([moleculer-addons](https://github.com/ice-services/moleculer-addons))
 
 ------------------------------
 
 ## v0.9.x
 - [ ] official Zipkin tracer service
 - [ ] add lru features to Memory and Redis cachers
-- [ ] Official services ([moleculer-addons](https://github.com/ice-services/moleculer-addons))
 
 ------------------------------
 

--- a/dev/dev.js
+++ b/dev/dev.js
@@ -3,7 +3,7 @@
 let ServiceBroker = require("../src/service-broker");
 let Transporter = require("../src/transporters/nats");
 let Serializer = require("../src/serializers/json");
-let { CustomError } = require("../src/errors");
+let { MoleculerError } = require("../src/errors");
 
 let broker1 = new ServiceBroker({
 	nodeID: "node1",
@@ -35,7 +35,7 @@ broker2.createService({
 	name: "devil",
 	actions: {
 		danger(ctx) {
-			throw new CustomError("Run!", 666, { a: 100 });
+			throw new MoleculerError("Run!", 666, { a: 100 });
 		}
 	}
 });*/

--- a/dev/dev.js
+++ b/dev/dev.js
@@ -35,7 +35,7 @@ broker2.createService({
 	name: "devil",
 	actions: {
 		danger(ctx) {
-			throw new MoleculerError("Run!", 666, { a: 100 });
+			throw new MoleculerError("Run!", 666, null, { a: 100 });
 		}
 	}
 });*/

--- a/examples/file.service.js
+++ b/examples/file.service.js
@@ -1,6 +1,6 @@
 const fs = require("fs");
 const path = require("path");
-const { CustomError } = require("../src/errors");
+const { MoleculerError } = require("../src/errors");
 
 module.exports = {
 	name: "file",

--- a/examples/file.service.js
+++ b/examples/file.service.js
@@ -1,6 +1,5 @@
 const fs = require("fs");
 const path = require("path");
-const { MoleculerError } = require("../src/errors");
 
 module.exports = {
 	name: "file",

--- a/examples/math.service.js
+++ b/examples/math.service.js
@@ -32,7 +32,7 @@ module.exports = {
 				if (b != 0 && !Number.isNaN(b))
 					return a / b;
 				else
-					throw new MoleculerError("Divide by zero!", 422, ctx.params);
+					throw new MoleculerError("Divide by zero!", 422, null, ctx.params);
 			}
 		}
 	}

--- a/examples/math.service.js
+++ b/examples/math.service.js
@@ -1,4 +1,4 @@
-const { CustomError } = require("../src/errors");
+const { MoleculerError } = require("../src/errors");
 
 module.exports = {
 	name: "math",
@@ -32,7 +32,7 @@ module.exports = {
 				if (b != 0 && !Number.isNaN(b))
 					return a / b;
 				else
-					throw new CustomError("Divide by zero!", 422, ctx.params);
+					throw new MoleculerError("Divide by zero!", 422, ctx.params);
 			}
 		}
 	}

--- a/examples/multi-server/server.js
+++ b/examples/multi-server/server.js
@@ -3,7 +3,7 @@
 let path = require("path");
 let _ = require("lodash");
 let ServiceBroker = require("../../src/service-broker");
-let { CustomError } = require("../../src/errors");
+let { MoleculerError } = require("../../src/errors");
 let NatsTransporter = require("../../src/transporters/nats");
 
 // Create broker
@@ -20,7 +20,7 @@ broker.createService({
 	actions: {
 		add(ctx) {
 			if (_.random(100) > 90)
-				return this.Promise.reject(new CustomError("Internal error!", 510));
+				return this.Promise.reject(new MoleculerError("Internal error!", 510));
 				
 			return Number(ctx.params.a) + Number(ctx.params.b);
 		},

--- a/examples/post.service.js
+++ b/examples/post.service.js
@@ -2,8 +2,6 @@ let _ = require("lodash");
 let fakerator = require("fakerator")();
 const Promise = require("bluebird");
 
-const { MoleculerError } = require("../src/errors");
-
 let { delay } = require("../src/utils");
 
 module.exports = function() {
@@ -64,7 +62,6 @@ module.exports = function() {
 			},
 
 			count(ctx) {
-				//throw new MoleculerError("Hibás adatok!", 410, ctx.params);
 				this.logger.info("count called");
 				let count = posts.filter(post => post.author == ctx.params.id).length;
 				//return Promise.delay(1500).then(() => count);

--- a/examples/post.service.js
+++ b/examples/post.service.js
@@ -2,7 +2,7 @@ let _ = require("lodash");
 let fakerator = require("fakerator")();
 const Promise = require("bluebird");
 
-const { CustomError } = require("../src/errors");
+const { MoleculerError } = require("../src/errors");
 
 let { delay } = require("../src/utils");
 
@@ -64,7 +64,7 @@ module.exports = function() {
 			},
 
 			count(ctx) {
-				//throw new CustomError("Hibás adatok!", 410, ctx.params);
+				//throw new MoleculerError("Hibás adatok!", 410, ctx.params);
 				this.logger.info("count called");
 				let count = posts.filter(post => post.author == ctx.params.id).length;
 				//return Promise.delay(1500).then(() => count);

--- a/index.d.ts
+++ b/index.d.ts
@@ -221,7 +221,7 @@ export = {
 	Validator: Validator,
 
 	Errors: {
-		CustomError: Error,
+		MoleculerError: Error,
 		ServiceNotFoundError: Error,
 		ValidationError: Error,
 		RequestTimeoutError: Error,

--- a/src/context.js
+++ b/src/context.js
@@ -130,7 +130,7 @@ class Context {
 			const distTimeout = this.timeout - duration;
 
 			if (distTimeout <= 0) {
-				return Promise.reject(new RequestSkippedError(actionName));
+				return Promise.reject(new RequestSkippedError(actionName, this.broker.nodeID));
 			}
 			opts.timeout = distTimeout;
 			//console.warn(`Decrement timeout: ${opts.timeout.toFixed(0)} for action '${actionName}'`);

--- a/src/context.js
+++ b/src/context.js
@@ -24,47 +24,6 @@ class Context {
 	 * 
 	 * @memberOf Context
 	 */
-	/*constructor(opts = {}) {
-		this.opts = opts;
-		this.broker = opts.broker;
-		this.action = opts.action;
-		this.nodeID = opts.nodeID;
-		this.parentID = opts.parent ? opts.parent.id : null;
-
-		this.metrics = !!opts.metrics;
-		this.level = opts.level || (opts.parent && opts.parent.level ? opts.parent.level + 1 : 1);
-
-		this.setParams(opts.params);
-
-		this.timeout = opts.timeout || 0;
-		this.retryCount = opts.retryCount || 0;
-
-		if (opts.parent && opts.parent.meta) {
-			// Merge metadata
-			this.meta = _.assign({}, opts.parent.meta, opts.meta);
-		} else {
-			this.meta = opts.meta || {};
-		}
-
-		// Generate ID for context
-		if (this.nodeID || opts.metrics)
-			this.id = opts.id || utils.generateToken();
-
-		// Initialize metrics properties
-		if (this.metrics) {
-			this.requestID = opts.requestID || (opts.parent && opts.parent.requestID ? opts.parent.requestID : undefined);
-
-			this.startTime = null;
-			this.startHrTime = null;
-			this.stopTime = null;
-			this.duration = 0;
-		}		
-
-		//this.error = null;
-		this.cachedResult = false;
-	}
-	*/
-
 	constructor(broker, action) {
 		this.id = null;
 		this.broker = broker;
@@ -226,6 +185,7 @@ class Context {
 				payload.error = {
 					name: error.name,
 					code: error.code,
+					type: error.type,
 					message: error.message
 				};
 			}

--- a/src/errors.js
+++ b/src/errors.js
@@ -9,24 +9,48 @@
 const ExtendableError = require("es6-error");
 
 /**
+ * Custom Moleculer Error class
+ * 
+ * @class MoleculerError
+ * @extends {Error}
+ */
+class MoleculerError extends ExtendableError {
+	/**
+	 * Creates an instance of MoleculerError.
+	 * 
+	 * @param {any} message
+	 * 
+	 * @memberOf MoleculerError
+	 */
+	constructor(message, code, type, data) {
+		super(message);
+		this.code = code || 500;
+		this.type = type;
+		this.data = data;
+	}
+}
+
+
+/**
  * 'Service not found' Error message
  * 
  * @class ServiceNotFoundError
  * @extends {Error}
  */
-class ServiceNotFoundError extends ExtendableError {
+class ServiceNotFoundError extends MoleculerError {
 	/**
 	 * Creates an instance of ServiceNotFoundError.
 	 * 
-	 * @param {String} message
-	 * @param {any} data
+	 * @param {String} action
+	 * @param {String} nodeID
 	 * 
 	 * @memberOf ServiceNotFoundError
 	 */
-	constructor(message, data) {
-		super(message);
-		this.code = 501;
-		this.data = data;
+	constructor(action, nodeID) {
+		super(`Service '${action}' is not available on '${nodeID || "<local>"}' node!`, 501, null, {
+			action,
+			nodeID
+		});
 	}
 }
 
@@ -36,7 +60,7 @@ class ServiceNotFoundError extends ExtendableError {
  * @class RequestTimeoutError
  * @extends {Error}
  */
-class RequestTimeoutError extends ExtendableError {
+class RequestTimeoutError extends MoleculerError {
 	/**
 	 * Creates an instance of RequestTimeoutError.
 	 * 
@@ -46,11 +70,10 @@ class RequestTimeoutError extends ExtendableError {
 	 * @memberOf RequestTimeoutError
 	 */
 	constructor(action, nodeID) {
-		super(`Request timed out when call '${action}' action on '${nodeID}' node!`);
-		this.code = 504;
-		this.nodeID = nodeID;
-		this.action = action;
-		//this.data = data;
+		super(`Request timed out when call '${action}' action on '${nodeID || "<local>"}' node!`, 504, null, {
+			action,
+			nodeID
+		});
 	}
 }
 
@@ -60,7 +83,7 @@ class RequestTimeoutError extends ExtendableError {
  * @class RequestSkippedError
  * @extends {Error}
  */
-class RequestSkippedError extends ExtendableError {
+class RequestSkippedError extends MoleculerError {
 	/**
 	 * Creates an instance of RequestSkippedError.
 	 * 
@@ -69,11 +92,9 @@ class RequestSkippedError extends ExtendableError {
 	 * @memberOf RequestSkippedError
 	 */
 	constructor(action) {
-		super(`Action '${action}' call is skipped because timeout reached!`);
-		this.code = 514;
-		//this.nodeID = nodeID;
-		this.action = action;
-		//this.data = data;
+		super(`Calling '${action}' is skipped because timeout reached!`, 514, null, {
+			action
+		});
 	}
 }
 
@@ -83,29 +104,28 @@ class RequestSkippedError extends ExtendableError {
  * @class ValidationError
  * @extends {Error}
  */
-class ValidationError extends ExtendableError {
+class ValidationError extends MoleculerError {
 	/**
 	 * Creates an instance of ValidationError.
 	 * 
-	 * @param {any} message
+	 * @param {String} message
+	 * @param {any} type
 	 * @param {any} data
 	 * 
 	 * @memberOf ValidationError
 	 */
-	constructor(message, data) {
-		super(message);
-		this.code = 422;
-		this.data = data;
+	constructor(message, type, data) {
+		super(message, 422, type, data);
 	}
 }
 
 /**
- * 'Request skipped for timeout' Error message
+ * 'Max request call level!' Error message
  * 
  * @class MaxCallLevelError
  * @extends {Error}
  */
-class MaxCallLevelError extends ExtendableError {
+class MaxCallLevelError extends MoleculerError {
 	/**
 	 * Creates an instance of MaxCallLevelError.
 	 * 
@@ -114,35 +134,14 @@ class MaxCallLevelError extends ExtendableError {
 	 * @memberOf MaxCallLevelError
 	 */
 	constructor(data) {
-		super("Call level is reached the limit!");
-		this.code = 500;
-		this.data = data;
+		super("Request call level is reached the limit!", 500, null, data);
 	}
 }
 
-/**
- * Custom Error class
- * 
- * @class CustomError
- * @extends {Error}
- */
-class CustomError extends ExtendableError {
-	/**
-	 * Creates an instance of CustomError.
-	 * 
-	 * @param {any} message
-	 * 
-	 * @memberOf CustomError
-	 */
-	constructor(message, code, data) {
-		super(message);
-		this.code = code || 500;
-		this.data = data;
-	}
-}
 
 module.exports = {
-	CustomError,
+	MoleculerError,
+
 	ServiceNotFoundError,
 	ValidationError,
 	RequestTimeoutError,

--- a/src/errors.js
+++ b/src/errors.js
@@ -47,7 +47,13 @@ class ServiceNotFoundError extends MoleculerError {
 	 * @memberOf ServiceNotFoundError
 	 */
 	constructor(action, nodeID) {
-		super(`Service '${action}' is not available on '${nodeID || "<local>"}' node!`, 501, null, {
+		let msg;
+		if (nodeID) 
+			msg = `Service '${action}' is not available on '${nodeID || "<local>"}' node!`;
+		else 
+			msg = `Service '${action}' is not available!`;
+			
+		super(msg, 501, null, {
 			action,
 			nodeID
 		});

--- a/src/errors.js
+++ b/src/errors.js
@@ -140,7 +140,7 @@ class MaxCallLevelError extends MoleculerError {
 	 * @memberOf MaxCallLevelError
 	 */
 	constructor(data) {
-		super("Request call level is reached the limit!", 500, null, data);
+		super("Request level is reached the limit!", 500, null, data);
 	}
 }
 

--- a/src/packets.js
+++ b/src/packets.js
@@ -244,6 +244,7 @@ class PacketResponse extends Packet {
 				message: err.message,
 				nodeID: err.nodeID || this.payload.sender,
 				code: err.code,
+				type: err.type,
 				stack: err.stack,
 				data: JSON.stringify(err.data)
 			};

--- a/src/serializers/avro.js
+++ b/src/serializers/avro.js
@@ -52,6 +52,7 @@ schemas[P.PACKET_RESPONSE] = avro.Type.forSchema({
 				{ name: "name", type: "string" },
 				{ name: "message", type: "string" },
 				{ name: "code", type: "int" },
+				{ name: "type", type: "string" },
 				{ name: "stack", type: "string" },
 				{ name: "data", type: "string" },
 				{ name: "nodeID", type: "string" }

--- a/src/serializers/proto/packets.proto
+++ b/src/serializers/proto/packets.proto
@@ -31,9 +31,10 @@ message PacketResponse {
 		required string name 		= 1;
 		required string message 	= 2;
 		required int32 code 		= 3;
-		required string data 		= 4;
-		required string stack 		= 5;
-		required string nodeID 		= 6;
+		required string type 		= 4;
+		required string data 		= 5;
+		required string stack 		= 6;
+		required string nodeID 		= 7;
 	}
 }
 

--- a/src/serializers/proto/packets.proto.js
+++ b/src/serializers/proto/packets.proto.js
@@ -1,4 +1,5 @@
--/*eslint-disable block-scoped-var, no-redeclare, no-control-regex, no-prototype-builtins, no-var, indent*/
+/*eslint-disable block-scoped-var, no-redeclare, no-control-regex, no-prototype-builtins, no-var, indent*/
+
 "use strict";
 
 var $protobuf = require("protobufjs/minimal");
@@ -835,6 +836,7 @@ $root.packets = (function() {
              * @property {string} name Error name.
              * @property {string} message Error message.
              * @property {number} code Error code.
+             * @property {string} type Error type.
              * @property {string} data Error data.
              * @property {string} stack Error stack.
              * @property {string} nodeID Error nodeID.
@@ -870,6 +872,12 @@ $root.packets = (function() {
              * @type {number}
              */
             Error.prototype.code = 0;
+
+            /**
+             * Error type.
+             * @type {string}
+             */
+            Error.prototype.type = "";
 
             /**
              * Error data.
@@ -910,9 +918,10 @@ $root.packets = (function() {
                 writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
                 writer.uint32(/* id 2, wireType 2 =*/18).string(message.message);
                 writer.uint32(/* id 3, wireType 0 =*/24).int32(message.code);
-                writer.uint32(/* id 4, wireType 2 =*/34).string(message.data);
-                writer.uint32(/* id 5, wireType 2 =*/42).string(message.stack);
-                writer.uint32(/* id 6, wireType 2 =*/50).string(message.nodeID);
+                writer.uint32(/* id 4, wireType 2 =*/34).string(message.type);
+                writer.uint32(/* id 5, wireType 2 =*/42).string(message.data);
+                writer.uint32(/* id 6, wireType 2 =*/50).string(message.stack);
+                writer.uint32(/* id 7, wireType 2 =*/58).string(message.nodeID);
                 return writer;
             };
 
@@ -951,12 +960,15 @@ $root.packets = (function() {
                         message.code = reader.int32();
                         break;
                     case 4:
-                        message.data = reader.string();
+                        message.type = reader.string();
                         break;
                     case 5:
-                        message.stack = reader.string();
+                        message.data = reader.string();
                         break;
                     case 6:
+                        message.stack = reader.string();
+                        break;
+                    case 7:
                         message.nodeID = reader.string();
                         break;
                     default:
@@ -970,6 +982,8 @@ $root.packets = (function() {
                     throw $util.ProtocolError("missing required 'message'", { instance: message });
                 if (!message.hasOwnProperty("code"))
                     throw $util.ProtocolError("missing required 'code'", { instance: message });
+                if (!message.hasOwnProperty("type"))
+                    throw $util.ProtocolError("missing required 'type'", { instance: message });
                 if (!message.hasOwnProperty("data"))
                     throw $util.ProtocolError("missing required 'data'", { instance: message });
                 if (!message.hasOwnProperty("stack"))
@@ -1006,6 +1020,8 @@ $root.packets = (function() {
                     return "message: string expected";
                 if (!$util.isInteger(message.code))
                     return "code: integer expected";
+                if (!$util.isString(message.type))
+                    return "type: string expected";
                 if (!$util.isString(message.data))
                     return "data: string expected";
                 if (!$util.isString(message.stack))
@@ -1030,6 +1046,8 @@ $root.packets = (function() {
                     message.message = String(object.message);
                 if (object.code != null)
                     message.code = object.code | 0;
+                if (object.type != null)
+                    message.type = String(object.type);
                 if (object.data != null)
                     message.data = String(object.data);
                 if (object.stack != null)
@@ -1062,6 +1080,7 @@ $root.packets = (function() {
                     object.name = "";
                     object.message = "";
                     object.code = 0;
+                    object.type = "";
                     object.data = "";
                     object.stack = "";
                     object.nodeID = "";
@@ -1072,6 +1091,8 @@ $root.packets = (function() {
                     object.message = message.message;
                 if (message.code != null && message.hasOwnProperty("code"))
                     object.code = message.code;
+                if (message.type != null && message.hasOwnProperty("type"))
+                    object.type = message.type;
                 if (message.data != null && message.hasOwnProperty("data"))
                     object.data = message.data;
                 if (message.stack != null && message.hasOwnProperty("stack"))

--- a/src/service-broker.js
+++ b/src/service-broker.js
@@ -743,7 +743,7 @@ class ServiceBroker {
 		const nodeID = ctx.nodeID;
 
 		if (!(err instanceof Error)) {
-			err = new E.CustomError(err);
+			err = new E.MoleculerError(err);
 		}
 		if (err instanceof Promise.TimeoutError)
 			err = new E.RequestTimeoutError(actionName, nodeID || this.nodeID);

--- a/src/service-broker.js
+++ b/src/service-broker.js
@@ -637,7 +637,7 @@ class ServiceBroker {
 				endpoint = this.serviceRegistry.getEndpointByNodeID(actionName, opts.nodeID);
 				if (!endpoint) {
 					this.logger.warn(`Service '${actionName}' is not available on '${opts.nodeID}' node!`);
-					return Promise.reject(new E.ServiceNotFoundError({ action: actionName, nodeID: opts.nodeID }));
+					return Promise.reject(new E.ServiceNotFoundError(actionName, opts.nodeID));
 				}
 
 			} else {
@@ -645,7 +645,7 @@ class ServiceBroker {
 				let actions = this.serviceRegistry.findAction(actionName);
 				if (actions == null) {
 					this.logger.warn(`Service '${actionName}' is not registered!`);
-					return Promise.reject(new E.ServiceNotFoundError({ action: actionName }));
+					return Promise.reject(new E.ServiceNotFoundError(actionName));
 				}
 				
 				// Get an endpoint
@@ -653,7 +653,7 @@ class ServiceBroker {
 				if (endpoint == null) {
 					const errMsg = `Service '${actionName}' is not available!`;
 					this.logger.warn(errMsg);
-					return Promise.reject(new E.ServiceNotFoundError({ action: actionName }));
+					return Promise.reject(new E.ServiceNotFoundError(actionName));
 				}
 			}
 		}

--- a/src/service-broker.js
+++ b/src/service-broker.js
@@ -636,26 +636,24 @@ class ServiceBroker {
 				// Direct call
 				endpoint = this.serviceRegistry.getEndpointByNodeID(actionName, opts.nodeID);
 				if (!endpoint) {
-					const errMsg = `Action '${actionName}' is not available on '${opts.nodeID}' node!`;
-					this.logger.warn(errMsg);
-					return Promise.reject(new E.ServiceNotFoundError(errMsg, { action: actionName, nodeID: opts.nodeID }));
+					this.logger.warn(`Service '${actionName}' is not available on '${opts.nodeID}' node!`);
+					return Promise.reject(new E.ServiceNotFoundError({ action: actionName, nodeID: opts.nodeID }));
 				}
 
 			} else {
 				// Find action by name
 				let actions = this.serviceRegistry.findAction(actionName);
 				if (actions == null) {
-					const errMsg = `Action '${actionName}' is not registered!`;
-					this.logger.warn(errMsg);
-					return Promise.reject(new E.ServiceNotFoundError(errMsg, { action: actionName }));
+					this.logger.warn(`Service '${actionName}' is not registered!`);
+					return Promise.reject(new E.ServiceNotFoundError({ action: actionName }));
 				}
 				
 				// Get an endpoint
 				endpoint = actions.nextAvailable();
 				if (endpoint == null) {
-					const errMsg = `Action '${actionName}' is not available!`;
+					const errMsg = `Service '${actionName}' is not available!`;
 					this.logger.warn(errMsg);
-					return Promise.reject(new E.ServiceNotFoundError(errMsg, { action: actionName }));
+					return Promise.reject(new E.ServiceNotFoundError({ action: actionName }));
 				}
 			}
 		}
@@ -743,7 +741,7 @@ class ServiceBroker {
 		const nodeID = ctx.nodeID;
 
 		if (!(err instanceof Error)) {
-			err = new E.MoleculerError(err);
+			err = new E.MoleculerError(err, 500);
 		}
 		if (err instanceof Promise.TimeoutError)
 			err = new E.RequestTimeoutError(actionName, nodeID || this.nodeID);

--- a/src/transit.js
+++ b/src/transit.js
@@ -329,6 +329,7 @@ class Transit {
 			//   let error = Object.create(constructor.prototype);
 			err.name = packet.error.name;
 			err.code = packet.error.code;
+			err.type = packet.error.type;
 			err.nodeID = packet.error.nodeID || packet.sender;
 			err.data = packet.error.data;
 			if (packet.error.stack)

--- a/src/validator.js
+++ b/src/validator.js
@@ -30,7 +30,7 @@ class ParamValidator {
 	validate(params, schema) {
 		const res = this.validator.validate(params, schema);
 		if (res !== true)
-			throw new ValidationError("Parameters validation error!", res);
+			throw new ValidationError("Parameters validation error!", null, res);
 		
 		return true;
 	}
@@ -50,7 +50,7 @@ class ParamValidator {
 					if (res === true)
 						return handler(ctx);
 					else
-						return Promise.reject(new ValidationError("Parameters validation error!", res));
+						return Promise.reject(new ValidationError("Parameters validation error!", null, res));
 				};
 			}
 			return handler;

--- a/test/integration/broker-transit.spec.js
+++ b/test/integration/broker-transit.spec.js
@@ -82,7 +82,7 @@ describe("Test RPC", () => {
 	it("should return with RequestTimeout", () => {
 		return b1.call("echo.slow", null, { timeout: 100 }).catch(err => {
 			expect(err).toBeInstanceOf(RequestTimeoutError);
-			expect(err.nodeID).toBe("node-2");
+			expect(err.data.nodeID).toBe("node-2");
 		});
 	});	
 

--- a/test/integration/circuit-breaker.spec.js
+++ b/test/integration/circuit-breaker.spec.js
@@ -1,7 +1,7 @@
 const Promise = require("bluebird");
 const ServiceBroker = require("../../src/service-broker");
 const FakeTransporter = require("../../src/transporters/fake");
-const { CustomError, ServiceNotFoundError } = require("../../src/errors");
+const { MoleculerError, ServiceNotFoundError } = require("../../src/errors");
 
 const lolex = require("lolex");
 
@@ -33,7 +33,7 @@ describe("Test circuit breaker", () => {
 
 			angry(ctx) {
 				if (ctx.params.please != true)
-					return Promise.reject(new CustomError("Don't call me!", 555));
+					return Promise.reject(new MoleculerError("Don't call me!", 555));
 				else
 					return "Just for you!";
 			},
@@ -66,14 +66,14 @@ describe("Test circuit breaker", () => {
 			.then(res => expect(res).toBe("OK"));
 	});
 
-	it("should return 'angry' with CustomError", () => {
+	it("should return 'angry' with MoleculerError", () => {
 		return master1.call("cb.angry")
 			.catch(err => {
-				expect(err.name).toBe("CustomError");
+				expect(err.name).toBe("MoleculerError");
 				return master1.call("cb.angry");
 			})
 			.catch(err => {
-				expect(err.name).toBe("CustomError");
+				expect(err.name).toBe("MoleculerError");
 				return master1.call("cb.angry");
 			})
 			.catch(err => {
@@ -89,7 +89,7 @@ describe("Test circuit breaker", () => {
 		clock.tick(6000);
 		return master1.call("cb.angry")
 			.catch(err => {
-				expect(err.name).toBe("CustomError");
+				expect(err.name).toBe("MoleculerError");
 				return "done";
 			})
 			.then(res => expect(res).toBe("done"))

--- a/test/integration/serializer.spec.js
+++ b/test/integration/serializer.spec.js
@@ -132,11 +132,11 @@ describe("Test JSON serializer", () => {
 	});		
 
 	it("should serialize the response packet with error", () => {
-		const err = new ValidationError("Invalid email!", { a: 5 });
+		const err = new ValidationError("Invalid email!", "ERR_INVALID_A", { a: 5 });
 		err.stack ="STACK_PLACEHOLDER";
 		const packet = new P.PacketResponse(broker.transit, "test-2", "12345", null, err);
 		const s = packet.serialize();
-		expect(s).toBe("{\"sender\":\"test-1\",\"id\":\"12345\",\"success\":false,\"data\":null,\"error\":{\"name\":\"ValidationError\",\"message\":\"Invalid email!\",\"nodeID\":\"test-1\",\"code\":422,\"stack\":\"STACK_PLACEHOLDER\",\"data\":\"{\\\"a\\\":5}\"}}");
+		expect(s).toBe("{\"sender\":\"test-1\",\"id\":\"12345\",\"success\":false,\"data\":null,\"error\":{\"name\":\"ValidationError\",\"message\":\"Invalid email!\",\"nodeID\":\"test-1\",\"code\":422,\"type\":\"ERR_INVALID_A\",\"stack\":\"STACK_PLACEHOLDER\",\"data\":\"{\\\"a\\\":5}\"}}");
 
 		const res = P.Packet.deserialize(broker.transit, P.PACKET_RESPONSE, s);
 		expect(res).toBeInstanceOf(P.PacketResponse);
@@ -146,6 +146,7 @@ describe("Test JSON serializer", () => {
 			message: "Invalid email!",
 			code: 422,
 			nodeID: "test-1",
+			type: "ERR_INVALID_A",
 			stack: "STACK_PLACEHOLDER",
 			data: {
 				a: 5
@@ -264,12 +265,12 @@ describe("Test Avro serializer", () => {
 	});		
 
 	it("should serialize the response packet with error", () => {
-		const err = new ValidationError("Invalid email!", { a: 5 });
+		const err = new ValidationError("Invalid email!", "ERR_INVALID_A", { a: 5 });
 		err.stack = "STACK_PLACEHOLDER";
 
 		const packet = new P.PacketResponse(broker.transit, "test-2", "12345", null, err);
 		const s = packet.serialize(100);
-		expect(s.length).toBe(82);
+		expect(s.length).toBe(96);
 
 		const res = P.Packet.deserialize(broker.transit, P.PACKET_RESPONSE, s);
 		expect(res).toBeInstanceOf(P.PacketResponse);
@@ -279,6 +280,7 @@ describe("Test Avro serializer", () => {
 			message: "Invalid email!",
 			code: 422,
 			nodeID: "test-1",
+			type: "ERR_INVALID_A",
 			stack: "STACK_PLACEHOLDER",
 			data: {
 				a: 5
@@ -399,12 +401,12 @@ describe("Test MsgPack serializer", () => {
 	});		
 
 	it("should serialize the response packet with error", () => {
-		const err = new ValidationError("Invalid email!", { a: 5 });
+		const err = new ValidationError("Invalid email!", "ERR_INVALID_A", { a: 5 });
 		err.stack = "STACK_PLACEHOLDER";
 
 		const packet = new P.PacketResponse(broker.transit, "test-2", "12345", null, err);
 		const s = packet.serialize();
-		expect(Buffer.byteLength(s, "binary")).toBe(149);
+		expect(Buffer.byteLength(s, "binary")).toBe(168);
 
 		const res = P.Packet.deserialize(broker.transit, P.PACKET_RESPONSE, s);
 		expect(res).toBeInstanceOf(P.PacketResponse);
@@ -413,6 +415,7 @@ describe("Test MsgPack serializer", () => {
 			name: "ValidationError",
 			message: "Invalid email!",
 			code: 422,
+			type: "ERR_INVALID_A",
 			nodeID: "test-1",
 			stack: "STACK_PLACEHOLDER",
 			data: {
@@ -532,12 +535,12 @@ describe("Test ProtoBuf serializer", () => {
 	});		
 
 	it("should serialize the response packet with error", () => {
-		const err = new ValidationError("Invalid email!", { a: 5 });
+		const err = new ValidationError("Invalid email!", "ERR_INVALID_A", { a: 5 });
 		err.stack = "STACK_PLACEHOLDER";
 
 		const packet = new P.PacketResponse(broker.transit, "test-2", "12345", null, err);
 		const s = packet.serialize(100);
-		expect(s.length).toBe(91);
+		expect(s.length).toBe(106);
 
 		const res = P.Packet.deserialize(broker.transit, P.PACKET_RESPONSE, s);
 		expect(res).toBeInstanceOf(P.PacketResponse);
@@ -546,6 +549,7 @@ describe("Test ProtoBuf serializer", () => {
 			name: "ValidationError",
 			message: "Invalid email!",
 			code: 422,
+			type: "ERR_INVALID_A",
 			stack: "STACK_PLACEHOLDER",
 			nodeID: "test-1",
 			data: {

--- a/test/unit/context.spec.js
+++ b/test/unit/context.spec.js
@@ -137,7 +137,7 @@ describe("Test call method", () => {
 			return ctx.call("posts.find", {});
 		}).catch(err => {
 			expect(err).toBeInstanceOf(RequestSkippedError);
-			expect(err.action).toBe("posts.find");
+			expect(err.data.action).toBe("posts.find");
 		});
 	});
 });
@@ -228,12 +228,12 @@ describe("Test _metricFinish method", () => {
 	it("should emit finish event with error", () => {		
 		broker.emit.mockClear();
 		return new Promise(resolve => {
-			ctx._metricFinish(new ServiceNotFoundError("Something happened"), true);
+			ctx._metricFinish(new ServiceNotFoundError("posts.find"), true);
 
 			expect(ctx.stopTime).toBeGreaterThan(0);
 
 			expect(broker.emit).toHaveBeenCalledTimes(1);
-			expect(broker.emit).toHaveBeenCalledWith("metrics.trace.span.finish", {"action": {"name": "users.get"}, "duration": ctx.duration, "error": { "message": "Something happened", "name": "ServiceNotFoundError", "code": 501 }, "id": ctx.id, "parent": 123, "requestID": ctx.requestID, "startTime": ctx.startTime, "endTime": ctx.stopTime, "fromCache": false, "level": 1, "remoteCall": true, "nodeID": broker.nodeID, "targetNodeID": "server-2" });
+			expect(broker.emit).toHaveBeenCalledWith("metrics.trace.span.finish", {"action": {"name": "users.get"}, "duration": ctx.duration, "error": { "message": "Service 'posts.find' is not available!", "name": "ServiceNotFoundError", "code": 501 }, "id": ctx.id, "parent": 123, "requestID": ctx.requestID, "startTime": ctx.startTime, "endTime": ctx.stopTime, "fromCache": false, "level": 1, "remoteCall": true, "nodeID": broker.nodeID, "targetNodeID": "server-2" });
 
 			resolve();
 		});

--- a/test/unit/context.spec.js
+++ b/test/unit/context.spec.js
@@ -3,7 +3,7 @@
 let Promise = require("bluebird");
 let Context = require("../../src/context");
 let ServiceBroker = require("../../src/service-broker");
-let { ServiceNotFoundError, RequestSkippedError } = require("../../src/errors");
+let { MoleculerError, RequestSkippedError } = require("../../src/errors");
 
 
 describe("Test Context", () => {
@@ -228,12 +228,12 @@ describe("Test _metricFinish method", () => {
 	it("should emit finish event with error", () => {		
 		broker.emit.mockClear();
 		return new Promise(resolve => {
-			ctx._metricFinish(new ServiceNotFoundError("posts.find"), true);
+			ctx._metricFinish(new MoleculerError("Some error!", 511, "ERR_CUSTOM", { a: 5 }), true);
 
 			expect(ctx.stopTime).toBeGreaterThan(0);
 
 			expect(broker.emit).toHaveBeenCalledTimes(1);
-			expect(broker.emit).toHaveBeenCalledWith("metrics.trace.span.finish", {"action": {"name": "users.get"}, "duration": ctx.duration, "error": { "message": "Service 'posts.find' is not available!", "name": "ServiceNotFoundError", "code": 501 }, "id": ctx.id, "parent": 123, "requestID": ctx.requestID, "startTime": ctx.startTime, "endTime": ctx.stopTime, "fromCache": false, "level": 1, "remoteCall": true, "nodeID": broker.nodeID, "targetNodeID": "server-2" });
+			expect(broker.emit).toHaveBeenCalledWith("metrics.trace.span.finish", {"action": {"name": "users.get"}, "duration": ctx.duration, "error": { "message": "Some error!", "name": "MoleculerError", "code": 511, "type": "ERR_CUSTOM" }, "id": ctx.id, "parent": 123, "requestID": ctx.requestID, "startTime": ctx.startTime, "endTime": ctx.stopTime, "fromCache": false, "level": 1, "remoteCall": true, "nodeID": broker.nodeID, "targetNodeID": "server-2" });
 
 			resolve();
 		});

--- a/test/unit/errors.spec.js
+++ b/test/unit/errors.spec.js
@@ -5,13 +5,13 @@ let errors = require("../../src/errors");
 
 describe("Test Errors", () => {
 
-	it("test CustomError", () => {
-		let err = new errors.CustomError("Something went wrong!", 555, { a: 5 });
+	it("test MoleculerError", () => {
+		let err = new errors.MoleculerError("Something went wrong!", 555, { a: 5 });
 		expect(err).toBeDefined();
 		expect(err).toBeInstanceOf(Error);
-		expect(err).toBeInstanceOf(errors.CustomError);
+		expect(err).toBeInstanceOf(errors.MoleculerError);
 		expect(err.code).toBe(555);
-		expect(err.name).toBe("CustomError");
+		expect(err.name).toBe("MoleculerError");
 		expect(err.message).toBe("Something went wrong!");
 		expect(err.data).toEqual({ a: 5});
 	});

--- a/test/unit/errors.spec.js
+++ b/test/unit/errors.spec.js
@@ -6,13 +6,14 @@ let errors = require("../../src/errors");
 describe("Test Errors", () => {
 
 	it("test MoleculerError", () => {
-		let err = new errors.MoleculerError("Something went wrong!", 555, { a: 5 });
+		let err = new errors.MoleculerError("Something went wrong!", 555, "ERR_TYPE", { a: 5 });
 		expect(err).toBeDefined();
 		expect(err).toBeInstanceOf(Error);
 		expect(err).toBeInstanceOf(errors.MoleculerError);
-		expect(err.code).toBe(555);
 		expect(err.name).toBe("MoleculerError");
 		expect(err.message).toBe("Something went wrong!");
+		expect(err.code).toBe(555);
+		expect(err.type).toBe("ERR_TYPE");
 		expect(err.data).toEqual({ a: 5});
 	});
 
@@ -23,18 +24,18 @@ describe("Test Errors", () => {
 		expect(err).toBeInstanceOf(errors.MaxCallLevelError);
 		expect(err.code).toBe(500);
 		expect(err.name).toBe("MaxCallLevelError");
-		expect(err.message).toBe("Call level is reached the limit!");
+		expect(err.message).toBe("Request level is reached the limit!");
 		expect(err.data).toEqual({ level: 10 });
 	});
 
 	it("test ServiceNotFoundError", () => {
-		let err = new errors.ServiceNotFoundError("Something went wrong!", { action: "posts.find" });
+		let err = new errors.ServiceNotFoundError("posts.find");
 		expect(err).toBeDefined();
 		expect(err).toBeInstanceOf(Error);
 		expect(err).toBeInstanceOf(errors.ServiceNotFoundError);
 		expect(err.code).toBe(501);
 		expect(err.name).toBe("ServiceNotFoundError");
-		expect(err.message).toBe("Something went wrong!");
+		expect(err.message).toBe("Service 'posts.find' is not available!");
 		expect(err.data).toEqual({ action: "posts.find" });
 	});
 
@@ -49,8 +50,7 @@ describe("Test Errors", () => {
 		expect(err.code).toBe(504);
 		expect(err.name).toBe("RequestTimeoutError");
 		expect(err.message).toBe("Request timed out when call 'posts.find' action on 'server-2' node!");
-		expect(err.nodeID).toBe("server-2");
-		//expect(err.data).toBe(data);
+		expect(err.data.nodeID).toBe("server-2");
 	});
 
 	it("test RequestSkippedError", () => {
@@ -60,20 +60,19 @@ describe("Test Errors", () => {
 		expect(err).toBeInstanceOf(errors.RequestSkippedError);
 		expect(err.code).toBe(514);
 		expect(err.name).toBe("RequestSkippedError");
-		expect(err.message).toBe("Action 'posts.find' call is skipped because timeout reached!");
-		//expect(err.nodeID).toBe("server-2");
-		//expect(err.data).toBe(data);
+		expect(err.message).toBe("Calling 'posts.find' is skipped because timeout reached!");
 	});
 
 	it("test ValidationError", () => {
 		let data = {};
-		let err = new errors.ValidationError("Param is not correct!", data);
+		let err = new errors.ValidationError("Param is not correct!", "ERR_TYPE", data);
 		expect(err).toBeDefined();
 		expect(err).toBeInstanceOf(Error);
 		expect(err).toBeInstanceOf(errors.ValidationError);
-		expect(err.code).toBe(422);
 		expect(err.name).toBe("ValidationError");
 		expect(err.message).toBe("Param is not correct!");
+		expect(err.code).toBe(422);
+		expect(err.type).toBe("ERR_TYPE");
 		expect(err.data).toBe(data);
 	});
 

--- a/test/unit/packets.spec.js
+++ b/test/unit/packets.spec.js
@@ -275,7 +275,7 @@ describe("Test PacketResponse", () => {
 	});
 
 	it("should set properties with error", () => {
-		let err = new ValidationError("Validation error", { a: 5 });
+		let err = new ValidationError("Validation error", "ERR_INVALID_A", { a: 5 });
 		let packet = new P.PacketResponse(transit, "server-2", "12345", null, err);
 		expect(packet).toBeDefined();
 		expect(packet.type).toBe(P.PACKET_RESPONSE);
@@ -289,6 +289,7 @@ describe("Test PacketResponse", () => {
 		expect(packet.payload.error.name).toBe("ValidationError");
 		expect(packet.payload.error.message).toBe("Validation error");
 		expect(packet.payload.error.code).toBe(422);
+		expect(packet.payload.error.type).toBe("ERR_INVALID_A");
 		expect(packet.payload.error.nodeID).toBe("node-1");
 		expect(packet.payload.error.data).toBe("{\"a\":5}");
 	});
@@ -311,6 +312,7 @@ describe("Test PacketResponse", () => {
 				name: "MoleculerError",
 				message: "Something happened",
 				code: 500,
+				type: "ERR_SOMETHING",
 				nodeID: "far-far-node",
 				data: "{\"a\":5}"
 			}
@@ -323,6 +325,7 @@ describe("Test PacketResponse", () => {
 		expect(packet.payload.error.name).toBe("MoleculerError");
 		expect(packet.payload.error.message).toBe("Something happened");
 		expect(packet.payload.error.code).toBe(500);
+		expect(packet.payload.error.type).toBe("ERR_SOMETHING");
 		expect(packet.payload.error.nodeID).toBe("far-far-node");
 		expect(packet.payload.error.data).toEqual({ a: 5 });	
 	});

--- a/test/unit/packets.spec.js
+++ b/test/unit/packets.spec.js
@@ -308,7 +308,7 @@ describe("Test PacketResponse", () => {
 		let payload = {
 			data: null,
 			error: {
-				name: "CustomError",
+				name: "MoleculerError",
 				message: "Something happened",
 				code: 500,
 				nodeID: "far-far-node",
@@ -320,7 +320,7 @@ describe("Test PacketResponse", () => {
 
 		expect(packet.payload.data).toBeNull();
 		expect(packet.payload.error).toBeDefined();
-		expect(packet.payload.error.name).toBe("CustomError");
+		expect(packet.payload.error.name).toBe("MoleculerError");
 		expect(packet.payload.error.message).toBe("Something happened");
 		expect(packet.payload.error.code).toBe(500);
 		expect(packet.payload.error.nodeID).toBe("far-far-node");

--- a/test/unit/service-broker.spec.js
+++ b/test/unit/service-broker.spec.js
@@ -852,7 +852,7 @@ describe("Test broker.call method", () => {
 			return broker.call("posts.noaction").catch(err => {
 				expect(err).toBeDefined();
 				expect(err).toBeInstanceOf(ServiceNotFoundError);
-				expect(err.message).toBe("Action 'posts.noaction' is not registered!");
+				expect(err.message).toBe("Service 'posts.noaction' is not available!");
 				expect(err.data).toEqual({ action: "posts.noaction" });
 			});
 		});
@@ -862,7 +862,7 @@ describe("Test broker.call method", () => {
 			return broker.call("posts.noHandler").catch(err => {
 				expect(err).toBeDefined();
 				expect(err).toBeInstanceOf(ServiceNotFoundError);
-				expect(err.message).toBe("Action 'posts.noHandler' is not available!");
+				expect(err.message).toBe("Service 'posts.noHandler' is not available!");
 				expect(err.data).toEqual({ action: "posts.noHandler" });
 			});
 		});
@@ -872,7 +872,7 @@ describe("Test broker.call method", () => {
 			return broker.call("posts.noHandler", {}, { nodeID: "node-123"}).catch(err => {
 				expect(err).toBeDefined();
 				expect(err).toBeInstanceOf(ServiceNotFoundError);
-				expect(err.message).toBe("Action 'posts.noHandler' is not available on 'node-123' node!");
+				expect(err.message).toBe("Service 'posts.noHandler' is not available on 'node-123' node!");
 				expect(err.data).toEqual({ action: "posts.noHandler", nodeID: "node-123" });
 			});
 		});

--- a/test/unit/service-broker.spec.js
+++ b/test/unit/service-broker.spec.js
@@ -11,7 +11,7 @@ const Transit = require("../../src/transit");
 const MemoryCacher = require("../../src/cachers/memory");
 const JSONSerializer = require("../../src/serializers/json");
 const FakeTransporter = require("../../src/transporters/fake"); 
-const { CustomError, ServiceNotFoundError, RequestTimeoutError, MaxCallLevelError } = require("../../src/errors");
+const { MoleculerError, ServiceNotFoundError, RequestTimeoutError, MaxCallLevelError } = require("../../src/errors");
 
 jest.mock("../../src/utils", () => ({
 	getNodeID() { return "node-1234"; },
@@ -571,7 +571,7 @@ describe("Test broker.wrapContextInvoke", () => {
 		});
 		broker.statistics.addRequest = jest.fn();
 
-		let origHandler = jest.fn(() => Promise.reject(new CustomError("Something went wrong!", 402)));
+		let origHandler = jest.fn(() => Promise.reject(new MoleculerError("Something went wrong!", 402)));
 		let action = {
 			name: "list",
 			handler: origHandler
@@ -585,7 +585,7 @@ describe("Test broker.wrapContextInvoke", () => {
 			ctx._metricFinish = jest.fn();
 
 			return action.handler(ctx).catch(err => {
-				expect(err).toBeInstanceOf(CustomError);
+				expect(err).toBeInstanceOf(MoleculerError);
 				expect(err.message).toBe("Something went wrong!");
 				expect(err.ctx).toBe(ctx);
 				expect(ctx._metricStart).toHaveBeenCalledTimes(1);
@@ -612,11 +612,11 @@ describe("Test broker.wrapContextInvoke", () => {
 		};
 		broker.wrapContextInvoke(action, origHandler);
 		
-		it("should convert error message to CustomError", () => {
+		it("should convert error message to MoleculerError", () => {
 			let ctx = new Context(broker, action);
 
 			return action.handler(ctx).catch(err => {
-				expect(err).toBeInstanceOf(CustomError);
+				expect(err).toBeInstanceOf(MoleculerError);
 				expect(err.message).toBe("My custom error message");
 				expect(err.code).toBe(500);
 				expect(err.ctx).toBe(ctx);
@@ -1164,7 +1164,7 @@ describe("Test broker._callErrorHandler", () => {
 	ctx.nodeID = "server-2";
 	ctx.metrics = true;
 
-	let customErr = new CustomError("Error", 400);
+	let customErr = new MoleculerError("Error", 400);
 	let timeoutErr = new RequestTimeoutError("user.create", "server-2");
 	ctx._metricFinish = jest.fn();
 	transit.removePendingRequest = jest.fn();
@@ -1191,7 +1191,7 @@ describe("Test broker._callErrorHandler", () => {
 
 	it("should call endpoint.failure if errorCode >= 500", () => {
 		endpoint.failure.mockClear();
-		return broker._callErrorHandler(new CustomError("Wrong", 500), ctx, endpoint, {}).catch(() => {
+		return broker._callErrorHandler(new MoleculerError("Wrong", 500), ctx, endpoint, {}).catch(() => {
 			expect(endpoint.failure).toHaveBeenCalledTimes(1);
 		});
 	});
@@ -1199,14 +1199,14 @@ describe("Test broker._callErrorHandler", () => {
 	it("should call endpoint.failure if errorCode >= 500", () => {
 		endpoint.failure.mockClear();
 		broker.options.circuitBreaker.failureOnReject = false;
-		return broker._callErrorHandler(new CustomError("Wrong", 500), ctx, endpoint, {}).catch(() => {
+		return broker._callErrorHandler(new MoleculerError("Wrong", 500), ctx, endpoint, {}).catch(() => {
 			expect(endpoint.failure).toHaveBeenCalledTimes(0);
 		});
 	});
 
-	it("should convert error text to CustomError", () => {
+	it("should convert error text to MoleculerError", () => {
 		return broker._callErrorHandler("Something happened", ctx, endpoint, {}).catch(err => {
-			expect(err).toBeInstanceOf(CustomError);
+			expect(err).toBeInstanceOf(MoleculerError);
 			expect(broker.call).toHaveBeenCalledTimes(0);
 		});
 	});
@@ -1293,7 +1293,7 @@ describe("Test broker._finishCall", () => {
 		it("should call ctx._metricFinish with error", () => {
 			ctx._metricFinish.mockClear();
 
-			let err = new CustomError("");
+			let err = new MoleculerError("");
 			broker._finishCall(ctx, err);
 
 			expect(ctx._metricFinish).toHaveBeenCalledTimes(1);
@@ -1323,7 +1323,7 @@ describe("Test broker._finishCall", () => {
 			ctx._metricFinish.mockClear();
 			broker.statistics.addRequest.mockClear();
 
-			let err = new CustomError("", 505);
+			let err = new MoleculerError("", 505);
 			broker._finishCall(ctx, err);
 
 			expect(ctx._metricFinish).toHaveBeenCalledTimes(1);
@@ -1355,7 +1355,7 @@ describe("Test broker._finishCall", () => {
 		it("should call statistics.addRequest with error", () => {
 			ctx._metricFinish.mockClear();
 			broker.statistics.addRequest.mockClear();
-			let err = new CustomError("", 505);
+			let err = new MoleculerError("", 505);
 			broker._finishCall(ctx, err);
 
 			expect(ctx._metricFinish).toHaveBeenCalledTimes(1);

--- a/test/unit/transit.spec.js
+++ b/test/unit/transit.spec.js
@@ -473,7 +473,7 @@ describe("Test Transit.sendResponse", () => {
 
 	it("should call publish with the error", () => {
 		transit.publish.mockClear();
-		transit.sendResponse("node2", "12345", null, new ValidationError("Not valid params", { a: "Too small" }));
+		transit.sendResponse("node2", "12345", null, new ValidationError("Not valid params", "ERR_INVALID_A_PARAM", { a: "Too small" }));
 		expect(transit.publish).toHaveBeenCalledTimes(1);
 		const packet = transit.publish.mock.calls[0][0];
 		expect(packet).toBeInstanceOf(P.PacketResponse);
@@ -485,6 +485,7 @@ describe("Test Transit.sendResponse", () => {
 		expect(packet.payload.error.name).toBe("ValidationError");
 		expect(packet.payload.error.message).toBe("Not valid params");
 		expect(packet.payload.error.code).toBe(422);
+		expect(packet.payload.error.type).toBe("ERR_INVALID_A_PARAM");
 		expect(packet.payload.error.nodeID).toBe("node1");
 		expect(packet.payload.error.data).toBe("{\"a\":\"Too small\"}");
 	});


### PR DESCRIPTION
The `CustomError` class renamed to `MoleculerError`. It got a `type` new property. You can store here a custom error type. E.g if you have a Validation error sometimes you don't enough the name & code. With `type` the client can handle the cause of error programmatically. 

**Example**
```js
const ERR_MISSING_ID = "ERR_MISSING_ID";
const ERR_ENTITY_NOT_FOUND = "ERR_ENTITY_NOT_FOUND";

broker.createService({
    actions: {
        get(ctx) {
            if (ctx.params.id) {
                const entity = this.searchEntity(ctx.params.id);
                if (entity)
                    return entity;
                else
                    return Promise.reject(new ValidationError("Not found entity!", ERR_ENTITY_NOT_FOUND));
            } else
                return Promise.reject(new ValidationError("Please set the ID field!", ERR_MISSING_ID));
        }
    }
});