### PR TITLE
Events mixins

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -46,7 +46,7 @@
 			"program": "${workspaceRoot}\\dev\\index.js",
 			"cwd": "${workspaceRoot}",
 			"args": [
-				"transit"
+				"mixins"
 			]
 		},		
 		{

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+<a name="0.8.1"></a>
+# 0.8.1 (2017-07-xx)
+
+# New
+
+## Improved mixin's merge logic
+The mixins merge logic is handle better events & lifecycle events. If you have a `created`, `started`, `stopped` lifecycle event or any other service event handler in your services, but your mixin has the same vent, Moleculer will call all of them in your service and in mixins. 
+
+[Read more about mixins](http://moleculer.services/docs/service.html#Mixins)
+
+--------------------------------------------------
+
 <a name="0.8.0"></a>
 # 0.8.0 (2017-06-21)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 # New
 
-## Improved mixin's merge logic
+## Improved mixin's merge logic [#50](https://github.com/ice-services/moleculer/issues/50/)
 The mixins merge logic is handle better events & lifecycle events. If you have a `created`, `started`, `stopped` lifecycle event or any other service event handler in your services, but your mixin has the same vent, Moleculer will call all of them in your service and in mixins. 
 
 [Read more about mixins](http://moleculer.services/docs/service.html#Mixins)

--- a/dev/mixins.js
+++ b/dev/mixins.js
@@ -18,7 +18,19 @@ let service1 = {
 		greeter(ctx) {
 			return this.greeting(ctx.params.name);
 		}
-	}
+	},
+
+	created() {
+		//this.logger.info("Created from service-1");
+	},
+
+	started() {
+		return Promise.resolve().then(() => this.logger.info("Started from service-1"));
+	},
+
+	stopped() {
+		this.logger.info("Stopped from service-1");
+	}	
 };
 
 let service2 = {
@@ -27,7 +39,25 @@ let service2 = {
 		greeting(name) {
 			return `Hello ${name}`;
 		}
-	}
+	},
+	created() {
+		//this.logger.info("Created from service-2");
+	},
+
+	started() {
+		this.logger.info("Started from service-2A");
+		return new Promise((resolve, reject) => {
+			setTimeout(() => {
+				this.logger.info("Started from service-2B");
+				//resolve();
+				reject(new Error("Cannot start service-2!"));
+			}, 500);
+		});
+	},
+
+	stopped() {
+		this.logger.info("Stopped from service-2");
+	}	
 };
 
 broker.createService({
@@ -36,12 +66,50 @@ broker.createService({
 		service1,
 		service2
 	],
+
 	actions: {
 		hello(ctx) {
 			return "Hello Mixins!";
 		}
-	}
+	},
+
+	/*created() {
+		this.logger.info("Created from mixed");
+	}*/
+	
+	started() {
+		this.logger.info("Started from mixed");
+	},
+
+	stopped() {
+		this.logger.info("Stopped from mixed");
+		//throw new Error("Can't stop mixed!");
+	}	
+
 });
 
-broker.call("mixed.hello").then(console.log);
-broker.call("mixed.greeter", { name: "John" }).then(console.log);
+broker.createService({
+	name: "normal",
+
+	created() {
+		this.logger.info("Normal created!");
+	},
+
+	started() {
+		this.logger.info("Normal started!");
+	},
+
+	stopped() {
+		this.logger.info("Normal stopped");
+		//throw new Error("Can't stop normal!");
+	}	
+});
+
+broker.start().then(() => {
+	broker.logger.info("Started!");
+}).timeout(1000).then(() => broker.stop())
+.then(() => broker.logger.info("Stopped!"))
+.catch(err => broker.logger.error("Can't start broker!", err));
+
+//broker.call("mixed.hello").then(console.log);
+//broker.call("mixed.greeter", { name: "John" }).then(console.log);

--- a/src/service-broker.js
+++ b/src/service-broker.js
@@ -248,17 +248,13 @@ class ServiceBroker {
 	start() {
 		return Promise.resolve()
 			.then(() => {
-			// Call service `started` handlers
-				this.services.forEach(service => {
-					if (service && service.schema && _.isFunction(service.schema.started)) {
-						service.schema.started.call(service);
-					}
-				});
-				return null; // avoid Bluebird warning
+				// Call service `started` handlers
+				return Promise.all(this.services.map(svc => svc.started.call(svc)));
 			})
 			.catch(err => {
-			/* istanbul ignore next */
+				/* istanbul ignore next */
 				this.logger.error("Unable to start all services!", err);
+				return Promise.reject(err);
 			})
 			.then(() => {
 				if (this.transit)
@@ -277,16 +273,11 @@ class ServiceBroker {
 	stop() {
 		return Promise.resolve()
 			.then(() => {
-			// Call service `started` handlers
-				this.services.forEach(service => {
-					if (service && service.schema && _.isFunction(service.schema.stopped)) {
-						service.schema.stopped.call(service);
-					}
-				});
-				return null; // avoid Bluebird warning
+				// Call service `started` handlers
+				return Promise.all(this.services.map(svc => svc.stopped.call(svc)));
 			})
 			.catch(err => {
-			/* istanbul ignore next */
+				/* istanbul ignore next */
 				this.logger.error("Unable to stop all services!", err);
 			})
 			.then(() => {

--- a/src/service.js
+++ b/src/service.js
@@ -204,8 +204,15 @@ class Service {
 	static applyMixins(schema) {
 		if (schema.mixins) {
 			const mixins = Array.isArray(schema.mixins) ? schema.mixins : [schema.mixins];
-			const mixedSchema = mixins.reduce((s, mixin) => utils.mergeSchemas(s, mixin), {});
-			return utils.mergeSchemas(mixedSchema, schema);
+			mixins.push(schema);
+			const mixedSchema = mixins.reduce((s, mixin) => {
+				console.log(`Mix ${s.name} to ${mixin.name}`);
+				let res = utils.mergeSchemas(s, mixin);
+				console.log(res);
+				return res;
+			}, {});
+			//return utils.mergeSchemas(mixedSchema, schema);
+			return mixedSchema;
 		} 
 		
 		/* istanbul ignore next */

--- a/src/service.js
+++ b/src/service.js
@@ -31,21 +31,18 @@ class Service {
 	 */
 	constructor(broker, schema) {
 
-		if (!isObject(broker)) {
-			throw new Error("Must to set a ServiceBroker instance!");
-		}
+		if (!isObject(broker))
+			throw new Error("Must set a ServiceBroker instance!");
 
-		if (!isObject(schema)) {
+		if (!isObject(schema))
 			throw new Error("Must pass a service schema in constructor!");
-		}
 
 		if (schema.mixins) {
 			schema = Service.applyMixins(schema);
 		}
 		
-		if (!schema.name) {
+		if (!schema.name)
 			throw new Error("Service name can't be empty!");
-		}
 
 		this.name = schema.name;
 		this.version = schema.version;
@@ -120,7 +117,7 @@ class Service {
 
 			forIn(schema.methods, (method, name) => {
 				/* istanbul ignore next */
-				if (["name", "version", "settings", "schema", "broker", "actions", "logger"].indexOf(name) != -1) {
+				if (["name", "version", "settings", "schema", "broker", "actions", "logger", "created", "started", "stopped"].indexOf(name) != -1) {
 					throw new Error(`Invalid method name '${name}' in '${this.name}' service!`);
 				}
 				this[name] = method.bind(this);
@@ -128,11 +125,39 @@ class Service {
 
 		}
 
-		// Call `created` function from schema
-		if (isFunction(this.schema.created)) {
-			this.schema.created.call(this);
-		}
+		// Create lifecycle runner methods
+		this.created = () => {
+			if (isFunction(this.schema.created)) {
+				this.schema.created.call(this);
+			} else if (Array.isArray(this.schema.created)) {
+				this.schema.created.forEach(fn => fn.call(this));
+			}
+		};
 
+		this.started = () => {
+			if (isFunction(this.schema.started))
+				return this.Promise.method(this.schema.started).call(this);
+
+			if (Array.isArray(this.schema.started)) {
+				return this.schema.started.map(fn => this.Promise.method(fn.bind(this))).reduce((p, fn) => p.then(fn), this.Promise.resolve());
+			}
+
+			return Promise.resolve();
+		};
+
+		this.stopped = () => {
+			if (isFunction(this.schema.stopped))
+				return this.Promise.method(this.schema.stopped).call(this);
+
+			if (Array.isArray(this.schema.stopped)) {
+				return this.schema.stopped.reverse().map(fn => this.Promise.method(fn.bind(this))).reduce((p, fn) => p.then(fn), this.Promise.resolve());
+			}
+
+			return Promise.resolve();
+		};
+
+		// Call the created event handler
+		this.created();
 	}
 
 	/**

--- a/src/utils.js
+++ b/src/utils.js
@@ -94,13 +94,16 @@ let utils = {
 		const res = _.cloneDeep(schema);
 
 		Object.keys(mods).forEach(key => {
-			if (["settings"].indexOf(key) !== -1)
+			if (["settings"].indexOf(key) !== -1) {
 				res[key] = _.defaultsDeep(mods[key], res[key]);
-			else if (["actions", "events", "methods"].indexOf(key) !== -1)
+			} else if (["actions", "events", "methods"].indexOf(key) !== -1) {
 				res[key] = _.assign(res[key], mods[key]);
-			else if (["created", "started", "stopped"].indexOf(key) !== -1) {
+			} else if (["created", "started", "stopped"].indexOf(key) !== -1) {
 				// Concat lifecycle event handlers
 				res[key] = _.compact(_.flatten([res[key], mods[key]]));
+			} else if (["mixins"].indexOf(key) !== -1) {
+				// Concat mixins
+				res[key] = _.compact(_.flatten([mods[key], res[key]]));
 			} else
 				updateProp(key, res, mods);
 		});

--- a/src/utils.js
+++ b/src/utils.js
@@ -98,7 +98,10 @@ let utils = {
 				res[key] = _.defaultsDeep(mods[key], res[key]);
 			else if (["actions", "events", "methods"].indexOf(key) !== -1)
 				res[key] = _.assign(res[key], mods[key]);
-			else
+			else if (["created", "started", "stopped"].indexOf(key) !== -1) {
+				// Concat lifecycle event handlers
+				res[key] = _.compact(_.flatten([res[key], mods[key]]));
+			} else
 				updateProp(key, res, mods);
 		});
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -96,8 +96,15 @@ let utils = {
 		Object.keys(mods).forEach(key => {
 			if (["settings"].indexOf(key) !== -1) {
 				res[key] = _.defaultsDeep(mods[key], res[key]);
-			} else if (["actions", "events", "methods"].indexOf(key) !== -1) {
+			} else if (["actions", "methods"].indexOf(key) !== -1) {
 				res[key] = _.assign(res[key], mods[key]);
+			} else if (["events"].indexOf(key) !== -1) {
+				if (res[key] == null)
+					res[key] = {};
+
+				Object.keys(mods[key]).forEach(k => {
+					res[key][k] = _.compact(_.flatten([res[key][k], mods[key][k]]));	
+				});
 			} else if (["created", "started", "stopped"].indexOf(key) !== -1) {
 				// Concat lifecycle event handlers
 				res[key] = _.compact(_.flatten([res[key], mods[key]]));

--- a/test/integration/service-mixins.spec.js
+++ b/test/integration/service-mixins.spec.js
@@ -73,6 +73,7 @@ describe.only("Test Service mixins", () => {
 
 	let mixin2L1 = {
 		name: "mixin2L1",
+		mixins: [mixinL2],
 		settings: {
 			b: 600,
 			e: "Susan"
@@ -91,6 +92,7 @@ describe.only("Test Service mixins", () => {
 		methods: {
 			jupiter: jest.fn(),
 			uranus: jest.fn(),
+			venus: jest.fn()
 		},
 
 		events: {
@@ -116,7 +118,9 @@ describe.only("Test Service mixins", () => {
 		},
 
 		actions: {
-
+			tango(ctx) {
+				return "From main";
+			}
 		},
 
 		methods: {
@@ -137,31 +141,138 @@ describe.only("Test Service mixins", () => {
 
 	let svc = broker.createService(mainSchema);
 
-	//console.log(svc.schema);
+	// console.log(svc.schema);
 
 	it("should call every created handler", () => {
 		expect(mainSchema.created).toHaveBeenCalledTimes(1);
 		expect(mixin1L1.created).toHaveBeenCalledTimes(1);
 		expect(mixin2L1.created).toHaveBeenCalledTimes(1);
-		expect(mixinL2.created).toHaveBeenCalledTimes(1);
+		expect(mixinL2.created).toHaveBeenCalledTimes(2);
 
 		return broker.start();
 	});		
-	/*
+	
 	it("should call every start handler", () => {
-		expect(mainStartedHandler).toHaveBeenCalledTimes(1);
+		expect(mainSchema.started).toHaveBeenCalledTimes(1);
+		expect(mixin2L1.started).toHaveBeenCalledTimes(1);
+		expect(mixinL2.started).toHaveBeenCalledTimes(2);
 	});
 
-	it("should called event handler", () => {
-		broker.emit("oxygen", { id: 1, name: "John" });
-		expect(mainEventHandler).toHaveBeenCalledTimes(1);
-		expect(mainEventHandler).toHaveBeenCalledWith({ id: 1, name: "John" }, undefined, "oxygen");
+	it("should merge settings", () => {
+		expect(svc.settings).toEqual({
+			a: 999,
+			b: 500,
+			c: "John",
+			d: "Adam",
+			e: "Susan",
+			f: "Bill"
+		});
+	});
 
-		return broker.stop();
+	it("should call 'beta' action", () => {
+		return broker.call("main.beta").then(res => {
+			expect(res).toBe("From mixin1L1");
+		});
+	});
+
+	it("should call 'delta' action", () => {
+		return broker.call("main.delta").then(res => {
+			expect(res).toBe("From mixin2L1");
+		});
+	});
+
+	it("should call 'gamma' action", () => {
+		return broker.call("main.gamma").then(res => {
+			expect(res).toBe("From mixin1L1");
+		});
+	});
+
+	it("should call 'alpha' action", () => {
+		return broker.call("main.alpha").then(res => {
+			expect(res).toBe("From mixinL2");
+		});
+	});
+
+	it("should call 'tango' action", () => {
+		return broker.call("main.tango").then(res => {
+			expect(res).toBe("From main");
+		});
+	});
+
+	it("should call 'jupiter' method", () => {
+		svc.jupiter();
+		
+		expect(mixin1L1.methods.jupiter).toHaveBeenCalledTimes(1);
+	});
+
+	it("should call 'uranus' method", () => {
+		svc.uranus();
+		
+		expect(mainSchema.methods.uranus).toHaveBeenCalledTimes(1);
+	});
+
+	it("should call 'saturn' method", () => {
+		svc.saturn();
+		
+		expect(mixin1L1.methods.saturn).toHaveBeenCalledTimes(1);
+	});
+
+	it("should call 'mars' method", () => {
+		svc.mars();
+		
+		expect(mixinL2.methods.mars).toHaveBeenCalledTimes(1);
+	});
+
+	it("should call 'venus' method", () => {
+		svc.venus();
+		
+		expect(mixin2L1.methods.venus).toHaveBeenCalledTimes(1);
+	});
+
+	it("should call 'oxygen' event handlers", () => {
+		let payload = { a: 5 };
+		broker.emit("oxygen", payload);
+
+		expect(mainSchema.events.oxygen).toHaveBeenCalledTimes(1);
+		expect(mainSchema.events.oxygen).toHaveBeenCalledWith(payload, undefined, "oxygen");
+			
+		expect(mixin1L1.events.oxygen).toHaveBeenCalledTimes(1);
+		expect(mixin1L1.events.oxygen).toHaveBeenCalledWith(payload, undefined, "oxygen");
+			
+		expect(mixin2L1.events.oxygen).toHaveBeenCalledTimes(1);
+		expect(mixin2L1.events.oxygen).toHaveBeenCalledWith(payload, undefined, "oxygen");
+			
+		expect(mixinL2.events.oxygen).toHaveBeenCalledTimes(2);
+		expect(mixinL2.events.oxygen).toHaveBeenCalledWith(payload, undefined, "oxygen");
 	});		
 
+	it("should call 'carbon' event handlers", () => {
+		let payload = { a: 5 };
+		broker.emit("carbon", payload);
+
+		expect(mainSchema.events.carbon).toHaveBeenCalledTimes(1);
+		expect(mainSchema.events.carbon).toHaveBeenCalledWith(payload, undefined, "carbon");
+	});		
+
+	it("should call 'hydrogen' event handlers", () => {
+		let payload = { a: 5 };
+		broker.emit("hydrogen", payload);
+
+		expect(mixin1L1.events.hydrogen).toHaveBeenCalledTimes(1);
+		expect(mixin1L1.events.hydrogen).toHaveBeenCalledWith(payload, undefined, "hydrogen");
+
+		expect(mixin2L1.events.hydrogen).toHaveBeenCalledTimes(1);
+		expect(mixin2L1.events.hydrogen).toHaveBeenCalledWith(payload, undefined, "hydrogen");
+	});		
+
+	it("calling broker.stop", () => {
+		return broker.stop();
+	});
+
 	it("should called stop handler", () => {
-		expect(mainStoppedHandler).toHaveBeenCalledTimes(1);
+		expect(mainSchema.stopped).toHaveBeenCalledTimes(1);
+		expect(mixin1L1.stopped).toHaveBeenCalledTimes(1);
+		expect(mixinL2.stopped).toHaveBeenCalledTimes(2);
 	});	
-*/
+
 });

--- a/test/integration/service-mixins.spec.js
+++ b/test/integration/service-mixins.spec.js
@@ -1,0 +1,167 @@
+let ServiceBroker = require("../../src/service-broker");
+
+describe.only("Test Service mixins", () => {
+
+	let mixinL2 = {
+		name: "mixinL2",
+
+		settings: {
+			a: 2,
+			b: "Steve",
+			c: "John"
+		},
+
+		actions: {
+			alpha: {
+				handler(ctx) {
+					return "From mixinL2";
+				}
+			},
+
+			beta: {
+				handler(ctx) {
+					return "From mixinL2";
+				}
+			}
+		},
+
+		methods: {
+			mars: jest.fn(),
+			jupiter: jest.fn()
+		},
+
+		events: {
+			"oxygen": jest.fn()
+		},
+
+		created: jest.fn(),
+		started: jest.fn(),
+		stopped: jest.fn()
+	};
+
+	let mixin1L1 = {
+		name: "mixin1L1",
+		mixins: [mixinL2],
+		settings: {
+			b: 500,
+			d: "Adam"
+		},
+
+		actions: {
+			beta(ctx) {
+				return "From mixin1L1";
+			},
+
+			gamma(ctx) {
+				return "From mixin1L1";
+			}
+		},
+
+		methods: {
+			jupiter: jest.fn(),
+			saturn: jest.fn()
+		},
+
+		events: {
+			"oxygen": jest.fn(),
+			"hydrogen": jest.fn()
+		},
+
+		created: jest.fn(),
+		stopped: jest.fn()
+	};
+
+	let mixin2L1 = {
+		name: "mixin2L1",
+		settings: {
+			b: 600,
+			e: "Susan"
+		},
+
+		actions :{
+			gamma(ctx) {
+				return "From mixin2L1";
+			},
+
+			delta(ctx) {
+				return "From mixin2L1";
+			}
+		},
+
+		methods: {
+			jupiter: jest.fn(),
+			uranus: jest.fn(),
+		},
+
+		events: {
+			"oxygen": jest.fn(),
+			"hydrogen": jest.fn()
+		},
+
+		created: jest.fn(),
+		started: jest.fn()
+	};
+
+	let mainSchema = {
+		name: "main",
+
+		mixins: [
+			mixin1L1,
+			mixin2L1
+		],
+
+		settings: {
+			a: 999,
+			f: "Bill"
+		},
+
+		actions: {
+
+		},
+
+		methods: {
+			uranus: jest.fn()
+		},
+
+		events: {
+			"oxygen": jest.fn(),
+			"carbon": jest.fn(),
+		},
+
+		created: jest.fn(),
+		started: jest.fn(),
+		stopped: jest.fn()
+	};
+
+	let broker = new ServiceBroker();
+
+	let svc = broker.createService(mainSchema);
+
+	//console.log(svc.schema);
+
+	it("should call every created handler", () => {
+		expect(mainSchema.created).toHaveBeenCalledTimes(1);
+		expect(mixin1L1.created).toHaveBeenCalledTimes(1);
+		expect(mixin2L1.created).toHaveBeenCalledTimes(1);
+		expect(mixinL2.created).toHaveBeenCalledTimes(1);
+
+		return broker.start();
+	});		
+	/*
+	it("should call every start handler", () => {
+		expect(mainStartedHandler).toHaveBeenCalledTimes(1);
+	});
+
+	it("should called event handler", () => {
+		broker.emit("oxygen", { id: 1, name: "John" });
+		expect(mainEventHandler).toHaveBeenCalledTimes(1);
+		expect(mainEventHandler).toHaveBeenCalledWith({ id: 1, name: "John" }, undefined, "oxygen");
+
+		return broker.stop();
+	});		
+
+	it("should called stop handler", () => {
+		expect(mainStoppedHandler).toHaveBeenCalledTimes(1);
+	});	
+*/
+});

--- a/test/integration/service-mixins.spec.js
+++ b/test/integration/service-mixins.spec.js
@@ -79,7 +79,7 @@ describe.only("Test Service mixins", () => {
 			e: "Susan"
 		},
 
-		actions :{
+		actions: {
 			gamma(ctx) {
 				return "From mixin2L1";
 			},
@@ -150,8 +150,8 @@ describe.only("Test Service mixins", () => {
 		expect(mixinL2.created).toHaveBeenCalledTimes(2);
 
 		return broker.start();
-	});		
-	
+	});
+
 	it("should call every start handler", () => {
 		expect(mainSchema.started).toHaveBeenCalledTimes(1);
 		expect(mixin2L1.started).toHaveBeenCalledTimes(1);
@@ -201,31 +201,26 @@ describe.only("Test Service mixins", () => {
 
 	it("should call 'jupiter' method", () => {
 		svc.jupiter();
-		
 		expect(mixin1L1.methods.jupiter).toHaveBeenCalledTimes(1);
 	});
 
 	it("should call 'uranus' method", () => {
 		svc.uranus();
-		
 		expect(mainSchema.methods.uranus).toHaveBeenCalledTimes(1);
 	});
 
 	it("should call 'saturn' method", () => {
 		svc.saturn();
-		
 		expect(mixin1L1.methods.saturn).toHaveBeenCalledTimes(1);
 	});
 
 	it("should call 'mars' method", () => {
 		svc.mars();
-		
 		expect(mixinL2.methods.mars).toHaveBeenCalledTimes(1);
 	});
 
 	it("should call 'venus' method", () => {
 		svc.venus();
-		
 		expect(mixin2L1.methods.venus).toHaveBeenCalledTimes(1);
 	});
 
@@ -235,16 +230,16 @@ describe.only("Test Service mixins", () => {
 
 		expect(mainSchema.events.oxygen).toHaveBeenCalledTimes(1);
 		expect(mainSchema.events.oxygen).toHaveBeenCalledWith(payload, undefined, "oxygen");
-			
+
 		expect(mixin1L1.events.oxygen).toHaveBeenCalledTimes(1);
 		expect(mixin1L1.events.oxygen).toHaveBeenCalledWith(payload, undefined, "oxygen");
-			
+
 		expect(mixin2L1.events.oxygen).toHaveBeenCalledTimes(1);
 		expect(mixin2L1.events.oxygen).toHaveBeenCalledWith(payload, undefined, "oxygen");
-			
+
 		expect(mixinL2.events.oxygen).toHaveBeenCalledTimes(2);
 		expect(mixinL2.events.oxygen).toHaveBeenCalledWith(payload, undefined, "oxygen");
-	});		
+	});
 
 	it("should call 'carbon' event handlers", () => {
 		let payload = { a: 5 };
@@ -252,7 +247,7 @@ describe.only("Test Service mixins", () => {
 
 		expect(mainSchema.events.carbon).toHaveBeenCalledTimes(1);
 		expect(mainSchema.events.carbon).toHaveBeenCalledWith(payload, undefined, "carbon");
-	});		
+	});
 
 	it("should call 'hydrogen' event handlers", () => {
 		let payload = { a: 5 };
@@ -263,7 +258,7 @@ describe.only("Test Service mixins", () => {
 
 		expect(mixin2L1.events.hydrogen).toHaveBeenCalledTimes(1);
 		expect(mixin2L1.events.hydrogen).toHaveBeenCalledWith(payload, undefined, "hydrogen");
-	});		
+	});
 
 	it("calling broker.stop", () => {
 		return broker.stop();
@@ -273,6 +268,6 @@ describe.only("Test Service mixins", () => {
 		expect(mainSchema.stopped).toHaveBeenCalledTimes(1);
 		expect(mixin1L1.stopped).toHaveBeenCalledTimes(1);
 		expect(mixinL2.stopped).toHaveBeenCalledTimes(2);
-	});	
+	});
 
 });

--- a/test/unit/utils.spec.js
+++ b/test/unit/utils.spec.js
@@ -168,4 +168,33 @@ describe("Test mergeSchemas", () => {
 
 	});
 
+	it("should concat tlifecycle events", () => {
+
+		let origSchema = {
+			created: jest.fn(),
+			started: jest.fn()
+		};
+
+		let newSchema = {
+			created: jest.fn(),
+			stopped: jest.fn()
+		};
+
+		let res = utils.mergeSchemas(origSchema, newSchema);
+
+		expect(res).toBeDefined();
+
+		expect(res.created).toBeInstanceOf(Array);
+		expect(res.created.length).toBe(2);
+		expect(res.created[0]).toBe(origSchema.created);
+		expect(res.created[1]).toBe(newSchema.created);
+
+		expect(res.started).toBe(origSchema.started);
+
+		expect(res.stopped).toBeInstanceOf(Array);
+		expect(res.stopped.length).toBe(1);
+		expect(res.stopped[0]).toBe(newSchema.stopped);
+
+	});
+
 });

--- a/test/unit/utils.spec.js
+++ b/test/unit/utils.spec.js
@@ -143,9 +143,13 @@ describe("Test mergeSchemas", () => {
 		expect(res.actions.list).toBe(newSchema.actions.list);
 		expect(res.actions.remove).toBe(newSchema.actions.remove);
 
-		expect(res.events.created).toBe(newSchema.events.created);
+		expect(res.events.created).toBeInstanceOf(Array);
+		expect(res.events.created[0]).toBe(origSchema.events.created);
+		expect(res.events.created[1]).toBe(newSchema.events.created);
+
 		expect(res.events.updated).toBe(origSchema.events.updated);
-		expect(res.events.removed).toBe(newSchema.events.removed);
+		expect(res.events.removed).toBeInstanceOf(Array);
+		expect(res.events.removed[0]).toBe(newSchema.events.removed);
 
 		expect(res.methods.getByID).toBe(newSchema.methods.getByID);
 		expect(res.methods.notify).toBe(origSchema.methods.notify);

--- a/test/unit/utils.spec.js
+++ b/test/unit/utils.spec.js
@@ -73,8 +73,9 @@ describe("Test mergeSchemas", () => {
 				notify() {}
 			},
 
-			created() {},
-			started() {}
+			created: jest.fn(),
+			started: jest.fn(),
+			stopped: jest.fn()
 		};
 
 		let newSchema = {
@@ -111,8 +112,9 @@ describe("Test mergeSchemas", () => {
 				checkPermission() {}
 			},
 
-			created() {},
-			stopped() {},
+			created: jest.fn(),
+			started: jest.fn(),
+			stopped: jest.fn(),
 
 			customProp: "test"			
 		};
@@ -149,9 +151,18 @@ describe("Test mergeSchemas", () => {
 		expect(res.methods.notify).toBe(origSchema.methods.notify);
 		expect(res.methods.checkPermission).toBe(newSchema.methods.checkPermission);
 		
-		expect(res.created).toBe(newSchema.created);
-		expect(res.started).toBe(origSchema.started);
-		expect(res.stopped).toBe(newSchema.stopped);
+		expect(res.created).toBeInstanceOf(Array);
+		expect(res.started).toBeInstanceOf(Array);
+		expect(res.stopped).toBeInstanceOf(Array);
+
+		expect(res.created[0]).toBe(origSchema.created);
+		expect(res.created[1]).toBe(newSchema.created);
+
+		expect(res.started[0]).toBe(origSchema.started);
+		expect(res.started[1]).toBe(newSchema.started);
+
+		expect(res.stopped[0]).toBe(origSchema.stopped);
+		expect(res.stopped[1]).toBe(newSchema.stopped);
 
 		expect(res.customProp).toBe("test");
 


### PR DESCRIPTION
## Improved mixin's merge logic
The mixins merge logic is handle better events & lifecycle events. If you have a `created`, `started`, `stopped` lifecycle event or any other service event handler in your services, but your mixin has the same event, Moleculer will call all of them in your service and in mixins. 