### PR TITLE
fix (service-broker) check if the returned promise has timeout property

### DIFF
--- a/src/service-broker.js
+++ b/src/service-broker.js
@@ -929,7 +929,7 @@ class ServiceBroker {
 			p = action.handler(ctx);
 
 			// Timeout handler
-			if (ctx.timeout > 0)
+			if (ctx.timeout > 0 && p.timeout)
 				p = p.timeout(ctx.timeout);
 
 			if (ctx.metrics === true || this.statistics) {
@@ -943,7 +943,7 @@ class ServiceBroker {
 			p = this.transit.request(ctx);
 
 			// Timeout handler
-			if (ctx.timeout > 0)
+			if (ctx.timeout > 0 && p.timeout)
 				p = p.timeout(ctx.timeout);
 		}
 


### PR DESCRIPTION
In one of my services the returned promise does not have the timeout property.

I assume for all other it does since I have other services that work fine without this change.