### PR TITLE
AMQP Transporter

### DIFF
--- a/src/service-broker.js
+++ b/src/service-broker.js
@@ -183,6 +183,8 @@ class ServiceBroker {
 				TransporterClass = Transporters.MQTT;
 			else if (opt.startsWith("redis://"))
 				TransporterClass = Transporters.Redis;
+			else if (opt.startsWith("amqp://"))
+				TransporterClass = Transporters.AMQP;
 
 			if (TransporterClass)
 				return new TransporterClass(opt);

--- a/src/transit.js
+++ b/src/transit.js
@@ -50,7 +50,7 @@ class Transit {
 		};
 
 		this.connected = false;
-		this.disconnecting = true;
+		this.disconnecting = false;
 
 		if (this.tx)
 			this.tx.init(this, this.messageHandler.bind(this), this.afterConnect.bind(this));

--- a/src/transporters/amqp.js
+++ b/src/transporters/amqp.js
@@ -79,12 +79,13 @@ class AmqpTransporter extends Transporter {
 					connection
 						.on("error", (err) => {
 							this.connected = false;
-							this.logger.error("AMQP connection error!", err);
+							reject(err);
+							this.logger.error("AMQP connection error!");
 						})
 						.on("close", (err) => {
 							this.connected = false;
-							const crashWorthy = require("amqplib/lib/connection").isFatalError(err);
-							this.logger.error("AMQP connection closed!", crashWorthy && err ||  "");
+							reject(err);
+							this.logger.error("AMQP connection closed!");
 						})
 						.on("blocked", (reason) => {
 							this.logger.warn("AMQP connection blocked!", reason);
@@ -106,11 +107,13 @@ class AmqpTransporter extends Transporter {
 							channel
 								.on("close", () => {
 									this.connected = false;
+									reject();
 									this.logger.warn("AMQP channel closed!");
 								})
-								.on("error", (error) => {
+								.on("error", (err) => {
 									this.connected = false;
-									this.logger.error("AMQP channel error!", error);
+									reject(err);
+									this.logger.error("AMQP channel error!");
 								})
 								.on("drain", () => {
 									this.logger.info("AMQP channel drained!");
@@ -121,13 +124,15 @@ class AmqpTransporter extends Transporter {
 						})
 						.catch((err) => {
 							/* istanbul ignore next*/
-							this.logger.error("AMQP failed to create channel!", err);
+							this.logger.error("AMQP failed to create channel!");
+							this.connected = false;
 							reject(err);
 						});
 				})
 				.catch((err) => {
 					/* istanbul ignore next*/
-					this.logger.error("AMQP failed to connect!", err);
+					this.logger.warn("AMQP failed to connect!");
+					this.connected = false;
 					reject(err);
 				});
 		});

--- a/src/transporters/amqp.js
+++ b/src/transporters/amqp.js
@@ -1,0 +1,329 @@
+/*
+ * moleculer
+ * Copyright (c) 2017 Ice Services (https://github.com/ice-services/moleculer)
+ * MIT Licensed
+ */
+
+"use strict";
+
+const Promise		= require("bluebird");
+const Transporter 	= require("./base");
+const {
+	PACKET_REQUEST,
+	PACKET_RESPONSE,
+	PACKET_UNKNOW,
+	PACKET_EVENT,
+	PACKET_DISCOVER,
+	PACKET_INFO,
+	PACKET_DISCONNECT,
+	PACKET_HEARTBEAT,
+} = require("../packets");
+
+/**
+ * Transporter for AMQP
+ *
+ * More info: https://www.amqp.org/
+ *
+ * @class AmqpTransporter
+ * @extends {Transporter}
+ */
+class AmqpTransporter extends Transporter {
+
+	/**
+	 * Creates an instance of AmqpTransporter.
+	 *
+	 * @param {any} opts
+	 *
+	 * @memberOf AmqpTransporter
+	 */
+	constructor(opts) {
+		if (typeof opts === "string")
+			opts = { amqp: { url: opts } };
+
+		// Number of requests a broker will handle concurrently
+		if (typeof opts.amqp.prefetch !== "number")
+			opts.amqp.prefetch = 1;
+
+		// Number of milliseconds before an event expires
+		if (typeof opts.amqp.eventTimeToLive !== "number")
+			opts.amqp.eventTimeToLive = 5000;
+
+		super(opts);
+
+		this.connection = null;
+		this.channel = null;
+		this.bindings = [];
+	}
+
+	/**
+	 * Connect to a AMQP server
+	 *
+	 * @memberOf AmqpTransporter
+	 */
+	connect() {
+		return new Promise((resolve, reject) => {
+			let amqp;
+			try {
+				amqp = require("amqplib");
+			} catch(err) {
+				/* istanbul ignore next */
+				this.broker.fatal("The 'amqplib' package is missing! Please install it with 'npm install amqplib --save' command!", err, true);
+			}
+
+			amqp.connect(this.opts.amqp.url)
+				.then(connection => {
+					this.connection = connection;
+					this.logger.info("AMQP connected!");
+
+					/* istanbul ignore next*/
+					connection
+						.on("error", (err) => {
+							this.connected = false;
+							this.logger.error("AMQP connection error!", err);
+						})
+						.on("close", (err) => {
+							this.connected = false;
+							const crashWorthy = require("amqplib/lib/connection").isFatalError(err);
+							this.logger.error("AMQP connection closed!", crashWorthy && err ||  "");
+						})
+						.on("blocked", (reason) => {
+							this.logger.warn("AMQP connection blocked!", reason);
+						})
+						.on("unblocked", () => {
+							this.logger.info("AMQP connection unblocked!");
+						});
+
+					connection
+						.createChannel()
+						.then((channel) => {
+							this.channel = channel;
+							this.onConnected().then(resolve);
+							this.logger.info("AMQP channel created!");
+
+							channel.prefetch(this.opts.amqp.prefetch);
+
+							/* istanbul ignore next*/
+							channel
+								.on("close", () => {
+									this.connected = false;
+									this.logger.warn("AMQP channel closed!");
+								})
+								.on("error", (error) => {
+									this.connected = false;
+									this.logger.error("AMQP channel error!", error);
+								})
+								.on("drain", () => {
+									this.logger.info("AMQP channel drained!");
+								})
+								.on("return", (msg) => {
+									this.logger.info("AMQP channel returned a message!", msg);
+								});
+						})
+						.catch((err) => {
+							/* istanbul ignore next*/
+							this.logger.error("AMQP failed to create channel!", err);
+							reject(err);
+						});
+				})
+				.catch((err) => {
+					/* istanbul ignore next*/
+					this.logger.error("AMQP failed to connect!", err);
+					reject(err);
+				});
+		});
+	}
+
+	/**
+	 * Disconnect from a AMQP server
+	 *
+	 * @memberOf AmqpTransporter
+	 * @description Close the connection and unbind this node's queues.
+	 * This prevents messages from being broadcasted to a dead node.
+	 * Note: Some methods of ending a node process don't allow disconnect to fire, meaning that
+	 * some dead nodes could still receive published packets.
+	 * Queues and Exchanges are not be deleted since they could contain important messages.
+	 */
+	disconnect() {
+		if (this.connection && this.channel && this.bindings) {
+			return Promise.all(this.bindings.map(binding => this.channel.unbindQueue(...binding)))
+				.then(() => this.channel.close())
+				.then(() => this.connection.close())
+				.then(() => {
+					this.bindings = null;
+					this.channel = null;
+					this.connection = null;
+				});
+		}
+	}
+
+	/**
+	 * Get assertQueue options by packet type.
+	 *
+	 * @param {String} packetType
+	 *
+	 * @memberOf AmqpTransporter
+	 */
+	_getQueueOptions(packetType) {
+		switch(packetType) {
+			// Requests and responses don't expire.
+			case PACKET_REQUEST:
+			case PACKET_RESPONSE:
+				return {};
+			// Packet types meant for internal use will expire after 5 seconds.
+			case PACKET_DISCOVER:
+			case PACKET_DISCONNECT:
+			case PACKET_UNKNOW:
+			case PACKET_INFO:
+			case PACKET_HEARTBEAT:
+				return { messageTtl: 5000 };
+			// Consumers can decide how long events live. Defaults to 5 seconds.
+			case PACKET_EVENT:
+				return { messageTtl: this.opts.amqp.eventTimeToLive };
+		}
+	}
+
+	/**
+	 * Build a function to handle requests.
+	 *
+	 * @param {String} cmd
+	 *
+	 * @memberOf AmqpTransporter
+	 */
+	_consumeCB(cmd) {
+		return (msg) => {
+			const result = this.messageHandler(cmd, msg.content);
+
+			// If a promise is returned, acknowledge the message after it has resolved.
+			// This means that if a worker dies after receiving a message but before responding, the
+			// message won't be lost and it can be retried.
+			if(cmd === PACKET_REQUEST) {
+				if (result instanceof Promise) {
+					return result.then(() => this.channel.ack(msg));
+				} else {
+					this.channel.ack(msg);
+				}
+			}
+		};
+	}
+
+
+	/**
+	 * Subscribe to a command
+	 *
+	 * @param {String} cmd
+	 * @param {String} nodeID
+	 *
+	 * @memberOf AmqpTransporter
+	 * @description Initialize queues and exchanges for all packet types except Request.
+	 *
+	 * All packets that should reach multiple nodes have a dedicated qeuue per node, and a single
+	 * exchange that routes each message to all queues. These packet types will not use
+	 * acknowledgements and have a set time-to-live. The time-to-live for EVENT packets can be
+	 * configured in options.
+	 * Examples: INFO (sometimes), DISCOVER, DISCONNECT, HEARTBEAT, EVENT
+	 *
+	 * Other Packets are headed towards a specific node or queue. These don't need exchanges and
+	 * packets of this type will not expire.
+	 * Examples: REQUEST, RESPONSE
+	 *
+	 * RESPONSE: Each node has its own dedicated queue and acknowledgements will not be used.
+	 *
+	 * REQUEST: Each action has its own dedicated queue. This way if an action has multiple workers,
+	 * they can all pull from the same qeuue. This allows a message to be retried by a different node
+	 * if one dies before responding.
+	 *
+	 * Note: Queue's for REQUEST packet types are not initialized in the subscribe method because the
+	 * actions themselves are not available from within the method. Instead they are intercepted from
+	 * "prefix.INFO" packets because they are broadcast whenever a service is registered.
+	 *
+	 */
+	subscribe(cmd, nodeID) {
+		if (!this.channel) return;
+
+		const topic = this.getTopicName(cmd, nodeID);
+
+		// Safer version of `if (topic.includes(nodeID))`.
+		// Some topics are specific to this node already, in these cases we don't need an exchange.
+		if ((cmd === PACKET_INFO && topic !== `${this.prefix}.${PACKET_INFO}`)
+			|| cmd === PACKET_RESPONSE) {
+			return this.channel.assertQueue(topic, this._getQueueOptions(cmd))
+				.then(() => this.channel.consume(topic, this._consumeCB(cmd), { noAck: true }));
+		} else if (cmd !== PACKET_REQUEST) {
+			// Create a queue specific to this nodeID so that this node can receive broadcasted messages.
+			const queueName = `${this.prefix}.${cmd}.${this.nodeID}`;
+
+			// Save binding arguments for easy unbinding later.
+			const bindingArgs = [queueName, topic, ""];
+			this.bindings.push(bindingArgs);
+
+			return Promise.all([
+				this.channel.assertExchange(topic, "fanout"),
+				this.channel.assertQueue(queueName, this._getQueueOptions(cmd)),
+			])
+				.then(() => Promise.all([
+					this.channel.bindQueue(...bindingArgs),
+					this.channel.consume(queueName, this._consumeCB(cmd), { noAck: true })
+				]));
+		}
+	}
+
+	/**
+	 * Parse a broker's services in order to initialize queues for REQUEST packets.
+	 *
+	 * @param {Array} services
+	 *
+	 * @memberOf AmqpTransporter
+	 */
+	_makeServiceSpecificSubscriptions(services) {
+		return Promise.all(services.map(service => service.schema)
+			.map((schema) => {
+				if (typeof schema.actions !== "object") return Promise.resolve();
+				const genericToService = `${this.prefix}.${PACKET_REQUEST}.${schema.name}`;
+
+				return Promise.all(
+					Object.keys(schema.actions)
+						.map((action) => {
+							const queue = `${genericToService}.${action}`;
+							return this.channel.assertQueue(queue, this._getQueueOptions(PACKET_REQUEST))
+								.then(() => this.channel.consume(queue, this._consumeCB(PACKET_REQUEST)));
+						})
+				);
+			}));
+	}
+
+	/**
+	 * Publish a packet
+	 *
+	 * @param {Packet} packet
+	 *
+	 * @memberOf AmqpTransporter
+	 * @description Send packets to their intended queues / exchanges.
+	 *
+	 * Reasonings documented in the subscribe method.
+	 */
+	publish(packet) {
+		if (!this.channel) return;
+
+		const topic = this.getTopicName(packet.type, packet.target);
+		const payload = new Buffer(packet.serialize()); // amqp.node expects data to be a buffer
+
+		let destination = packet.type === PACKET_REQUEST
+			?	`${this.prefix}.${packet.type}.${packet.payload.action}`
+			: topic;
+
+		if ((packet.type === PACKET_INFO && topic !== `${this.prefix}.${PACKET_INFO}`)
+			|| packet.type === PACKET_REQUEST
+			|| packet.type === PACKET_RESPONSE)
+			this.channel.sendToQueue(destination, payload);
+		else
+			this.channel.publish(destination, "", payload);
+
+		// HACK: This is the best way I have found to obtain the broker's services.
+		if (destination === `${this.prefix}.${PACKET_INFO}`) {
+			return this._makeServiceSpecificSubscriptions(packet.transit.broker.services);
+		}
+		return Promise.resolve();
+	}
+}
+
+module.exports = AmqpTransporter;

--- a/src/transporters/index.js
+++ b/src/transporters/index.js
@@ -11,5 +11,6 @@ module.exports = {
 	Fake: require("./fake"),
 	NATS: require("./nats"),
 	MQTT: require("./mqtt"),
-	Redis: require("./redis")
+	Redis: require("./redis"),
+	AMQP: require("./amqp")
 };

--- a/test/integration/amqp/events/events.spec.js
+++ b/test/integration/amqp/events/events.spec.js
@@ -1,0 +1,54 @@
+const path = require("path");
+const Promise = require("bluebird");
+const { exec, callIn } = require("../util");
+
+const commonString = " received the event.";
+
+const findResponse = (arr) => arr
+	.map(string => {
+		const line = string
+			.split("\n")
+			.find(a => a.indexOf(commonString) > 0);
+		return line ? line.slice(0, line.indexOf(commonString)) : false;
+	})
+	.filter(a => a);
+
+xdescribe("Test AMQPTransporter events", () => {
+	beforeEach(() => exec("node", [path.resolve(__dirname, "..", "purge.js")]));
+	afterAll(() => exec("node", [path.resolve(__dirname, "..", "purge.js")]));
+
+	it("Should send an event to all subscribed nodes.", () => {
+		return Promise.all([
+			exec("node", [path.resolve(__dirname,"pub.js")]),
+			exec("node", [path.resolve(__dirname,"sub1.js")]),
+			exec("node", [path.resolve(__dirname,"sub2.js")]),
+			exec("node", [path.resolve(__dirname,"sub3.js")]),
+		])
+			.then((stdout) => {
+				const expectedReceivers = [
+					"Publisher",
+					"Subscriber1",
+					"Subscriber2",
+					"Subscriber3",
+				].sort();
+				expect(findResponse(stdout).sort()).toEqual(expectedReceivers);
+			});
+	}, 15000);
+
+	it( "Subscribed nodes should not receive events older than 5 seconds.", () => {
+		return Promise.all([
+			callIn(() => exec("node", [path.resolve(__dirname,"pub.js")]), 200),
+			exec("node", [path.resolve(__dirname,"sub1.js")]),
+			exec("node", [path.resolve(__dirname,"sub2.js")]),
+			callIn(() => exec("node", [path.resolve(__dirname,"sub3.js")]), 6000),
+		])
+			.then((stdout) => {
+				const expectedReceivers = [
+					"Publisher",
+					"Subscriber1",
+					"Subscriber2",
+				].sort();
+				expect(findResponse(stdout).sort()).toEqual(expectedReceivers);
+			});
+	}, 20000);
+});

--- a/test/integration/amqp/events/pub.js
+++ b/test/integration/amqp/events/pub.js
@@ -1,0 +1,18 @@
+const { ServiceBroker, Transporters: { AMQP: AmqpTransport } } = require("../../../..");
+const AMQP_URL = "amqp://guest:guest@localhost:5672";
+const amqpTransporter = new AmqpTransport(AMQP_URL);
+
+const broker = new ServiceBroker({
+	nodeID: "event-pub-nodeID",
+	logger: console,
+	transporter: amqpTransporter,
+});
+
+broker.on("hello.world", () => {
+	console.log("Publisher received the event.");
+});
+
+setTimeout(() => process.exit(1), 10000);
+
+broker.start();
+setTimeout(() => broker.emit("hello.world", { testing: true }), 1000);

--- a/test/integration/amqp/events/sub1.js
+++ b/test/integration/amqp/events/sub1.js
@@ -1,0 +1,22 @@
+const { ServiceBroker, Transporters: { AMQP: AmqpTransport } } = require("../../../..");
+const AMQP_URL = "amqp://guest:guest@localhost:5672";
+const amqpTransporter = new AmqpTransport(AMQP_URL);
+
+const broker = new ServiceBroker({
+	nodeID: "event-sub1-nodeID",
+	logger: console,
+	transporter: amqpTransporter,
+});
+
+broker.createService({
+	name: "aService",
+	events: {
+		"hello.world": function(payload) {
+			console.log("Subscriber1 received the event.");
+		},
+	}
+});
+
+setTimeout(() => process.exit(1), 10000);
+
+broker.start();

--- a/test/integration/amqp/events/sub2.js
+++ b/test/integration/amqp/events/sub2.js
@@ -1,0 +1,22 @@
+const { ServiceBroker, Transporters: { AMQP: AmqpTransport } } = require("../../../..");
+const AMQP_URL = "amqp://guest:guest@localhost:5672";
+const amqpTransporter = new AmqpTransport(AMQP_URL);
+
+const broker = new ServiceBroker({
+	nodeID: "event-sub2-nodeID",
+	logger: console,
+	transporter: amqpTransporter,
+});
+
+broker.createService({
+	name: "aService",
+	events: {
+		"hello.world": function(payload) {
+			console.log("Subscriber2 received the event.");
+		},
+	}
+});
+
+setTimeout(() => process.exit(1), 10000);
+
+broker.start();

--- a/test/integration/amqp/events/sub3.js
+++ b/test/integration/amqp/events/sub3.js
@@ -1,0 +1,22 @@
+const { ServiceBroker, Transporters: { AMQP: AmqpTransport } } = require("../../../..");
+const AMQP_URL = "amqp://guest:guest@localhost:5672";
+const amqpTransporter = new AmqpTransport(AMQP_URL);
+
+const broker = new ServiceBroker({
+	nodeID: "event-sub3-nodeID",
+	logger: console,
+	transporter: amqpTransporter,
+});
+
+broker.createService({
+	name: "bService",
+	events: {
+		"hello.world": function(payload) {
+			console.log("Subscriber3 received the event.");
+		},
+	}
+});
+
+setTimeout(() => process.exit(1), 10000);
+
+broker.start();

--- a/test/integration/amqp/purge.js
+++ b/test/integration/amqp/purge.js
@@ -1,0 +1,120 @@
+const queueNames = [
+	"MOL.DISCONNECT.event-pub-nodeID",
+	"MOL.DISCONNECT.event-sub1-nodeID",
+	"MOL.DISCONNECT.event-sub2-nodeID",
+	"MOL.DISCONNECT.event-sub3-nodeID",
+	"MOL.DISCONNECT.five-request-nodeID",
+	"MOL.DISCONNECT.single-request-nodeID",
+	"MOL.DISCONNECT.slow-nodeID",
+	"MOL.DISCONNECT.timestamped-nodeID",
+	"MOL.DISCONNECT.too-slow-nodeID",
+	"MOL.DISCONNECT.worker1-nodeID",
+	"MOL.DISCONNECT.worker2-nodeID",
+	"MOL.DISCOVER.event-pub-nodeID",
+	"MOL.DISCOVER.event-sub1-nodeID",
+	"MOL.DISCOVER.event-sub2-nodeID",
+	"MOL.DISCOVER.event-sub3-nodeID",
+	"MOL.DISCOVER.five-request-nodeID",
+	"MOL.DISCOVER.single-request-nodeID",
+	"MOL.DISCOVER.slow-nodeID",
+	"MOL.DISCOVER.timestamped-nodeID",
+	"MOL.DISCOVER.too-slow-nodeID",
+	"MOL.DISCOVER.worker1-nodeID",
+	"MOL.DISCOVER.worker2-nodeID",
+	"MOL.EVENT.event-pub-nodeID",
+	"MOL.EVENT.event-sub1-nodeID",
+	"MOL.EVENT.event-sub2-nodeID",
+	"MOL.EVENT.event-sub3-nodeID",
+	"MOL.EVENT.five-request-nodeID",
+	"MOL.EVENT.single-request-nodeID",
+	"MOL.EVENT.slow-nodeID",
+	"MOL.EVENT.timestamped-nodeID",
+	"MOL.EVENT.too-slow-nodeID",
+	"MOL.EVENT.worker1-nodeID",
+	"MOL.EVENT.worker2-nodeID",
+	"MOL.HEARTBEAT.event-pub-nodeID",
+	"MOL.HEARTBEAT.event-sub1-nodeID",
+	"MOL.HEARTBEAT.event-sub2-nodeID",
+	"MOL.HEARTBEAT.event-sub3-nodeID",
+	"MOL.HEARTBEAT.five-request-nodeID",
+	"MOL.HEARTBEAT.single-request-nodeID",
+	"MOL.HEARTBEAT.slow-nodeID",
+	"MOL.HEARTBEAT.timestamped-nodeID",
+	"MOL.HEARTBEAT.too-slow-nodeID",
+	"MOL.HEARTBEAT.worker1-nodeID",
+	"MOL.HEARTBEAT.worker2-nodeID",
+	"MOL.INFO.event-pub-nodeID",
+	"MOL.INFO.event-sub1-nodeID",
+	"MOL.INFO.event-sub2-nodeID",
+	"MOL.INFO.event-sub3-nodeID",
+	"MOL.INFO.five-request-nodeID",
+	"MOL.INFO.single-request-nodeID",
+	"MOL.INFO.slow-nodeID",
+	"MOL.INFO.timestamped-nodeID",
+	"MOL.INFO.too-slow-nodeID",
+	"MOL.INFO.worker1-nodeID",
+	"MOL.INFO.worker2-nodeID",
+	"MOL.REQ.testing.hello",
+	"MOL.RES.event-pub-nodeID",
+	"MOL.RES.event-sub1-nodeID",
+	"MOL.RES.event-sub2-nodeID",
+	"MOL.RES.event-sub3-nodeID",
+	"MOL.RES.five-request-nodeID",
+	"MOL.RES.single-request-nodeID",
+	"MOL.RES.slow-nodeID",
+	"MOL.RES.timestamped-nodeID",
+	"MOL.RES.too-slow-nodeID",
+	"MOL.RES.worker1-nodeID",
+	"MOL.RES.worker2-nodeID",
+];
+const exchanges = [
+	"MOL.DISCONNECT",
+	"MOL.DISCOVER",
+	"MOL.EVENT",
+	"MOL.HEARTBEAT",
+	"MOL.INFO",
+];
+
+const amqp = require("amqplib");
+let connectionRef;
+
+amqp.connect("amqp://guest:guest@localhost:5672")
+	.then(connection => {
+		console.info("AMQP connected!");
+		connectionRef = connection;
+		return connection
+			.on("error", (err) => {
+				console.error("AMQP connection error!", err);
+				process.exit(1);
+			})
+			.on("close", (err) => {
+				const crashWorthy = require("amqplib/lib/connection").isFatalError(err);
+				console.error("AMQP connection closed!", crashWorthy && err ||  "");
+				process.exit(1);
+			})
+			.createChannel();
+	})
+	.then((channel) => {
+		console.info("AMQP channel created!");
+		channel
+			.on("close", () => {
+				console.warn("AMQP channel closed!");
+				process.exit(1);
+			})
+			.on("error", (error) => {
+				console.error("AMQP channel error!", error);
+				process.exit(1);
+			});
+
+		return Promise.all(queueNames.map(q => channel.deleteQueue(q)))
+			.then(() => Promise.all(exchanges.map(e => channel.deleteExchange(e))));
+	})
+	.then(() => {
+		console.log("Done.");
+		return connectionRef.close();
+	})
+	.then(() => process.exit(0))
+	.catch((err) => {
+		console.error("AMQP failed to create channel!", err);
+		process.exit(1);
+	});

--- a/test/integration/amqp/rpc/fiveRequests.js
+++ b/test/integration/amqp/rpc/fiveRequests.js
@@ -1,0 +1,42 @@
+const {
+	ServiceBroker,
+	Transporters: { AMQP: AmqpTransport }
+} = require("../../../..");
+const AMQP_URL = "amqp://guest:guest@localhost:5672";
+
+const amqpTransporter = new AmqpTransport(AMQP_URL);
+const broker = new ServiceBroker({
+	nodeID: "five-request-nodeID",
+	logger: console,
+	transporter: amqpTransporter,
+});
+
+broker.start();
+
+setTimeout(() => process.exit(1), 10000);
+
+setTimeout(() => {
+	broker.call("testing.hello", { cmd: "request" + (process.argv[2] || Date.now()) })
+		.then(console.log);
+}, 1000);
+
+setTimeout(() => {
+	broker.call("testing.hello", { cmd: "request" + (process.argv[3] || Date.now()) })
+		.then(console.log);
+}, 2000);
+
+setTimeout(() => {
+	broker.call("testing.hello", { cmd: "request" + (process.argv[4] || Date.now()) })
+		.then(console.log);
+}, 3000);
+
+setTimeout(() => {
+	broker.call("testing.hello", { cmd: "request" + (process.argv[5] || Date.now()) })
+		.then(console.log);
+}, 4000);
+
+setTimeout(() => {
+	broker.call("testing.hello", { cmd: "request" + (process.argv[6] || Date.now()) })
+		.then(console.log);
+}, 5000);
+

--- a/test/integration/amqp/rpc/rpc.spec.js
+++ b/test/integration/amqp/rpc/rpc.spec.js
@@ -1,0 +1,114 @@
+const path = require("path");
+const Promise = require("bluebird");
+const { exec, callIn } = require("../util");
+
+const respondTo = "responding to";
+const receive = "received";
+const respond = "responded";
+
+const findLines = (str, target) => str.split("\n").filter(a => a.includes(target));
+
+xdescribe("Test AMQPTransporter RPC", () => {
+	beforeEach(() => exec("node", [path.resolve(__dirname, "..", "purge.js")]));
+	afterAll(() => exec("node", [path.resolve(__dirname, "..", "purge.js")]));
+
+	it("Only one node should receive any given request.", () => {
+		const messageID = Date.now();
+		return Promise.all([
+			exec("node", [path.resolve(__dirname, "worker1.js")]),
+			callIn(() => exec("node", [path.resolve(__dirname, "worker2.js")]), 1000),
+			callIn(() => exec("node", [path.resolve(__dirname, "singleRequest.js"), messageID]), 1000),
+		])
+			.then((stdout) => {
+				const responses = stdout
+					.reduce((acc, string) => {
+						const lines = findLines(string, respondTo);
+						if (lines.length) {
+							return acc.concat(lines);
+						}
+						return acc;
+					}, []);
+
+				expect(responses).toHaveLength(1);
+				const oneOf = [
+					`worker1 responding to request${messageID}`,
+					`worker2 responding to request${messageID}`
+				];
+				expect(oneOf).toContain(responses[0]);
+			});
+	}, 15000);
+
+	it("Nodes should only receive one request at a time by default.", () => {
+		const messageID = Date.now();
+		return Promise.all([
+			exec("node", [path.resolve(__dirname, "timeStampedWorker.js")]),
+			exec("node", [path.resolve(__dirname, "fiveRequests.js"), messageID]),
+		])
+			.then((stdout) => {
+				const responses = stdout[0]
+					.split("\n")
+					.filter(a => a.indexOf(receive) !== -1 || a.indexOf(respond) !== -1);
+
+				expect(responses).toHaveLength(10);
+
+				const getType = a => a.split(" ")[0];
+				const getTime = a => Number(a.split(" ")[1]);
+
+				for (let i = 0; i < 10; i++) {
+					expect(getType(responses[i])).toBe(i % 2 === 0 ? receive : respond);
+				}
+
+				for (let i = 0; i < 9; i++) {
+					expect(getTime(responses[i])).toBeLessThan(getTime(responses[i + 1]));
+				}
+			});
+	}, 15000);
+
+	it("Should use availability-based load balancing", () => {
+		const getResponses = str => str.split("\n").filter(a => a.includes(respondTo));
+		return Promise.all([
+			exec("node", [path.resolve(__dirname, "slowWorker.js")]),
+			exec("node", [path.resolve(__dirname, "worker1.js")]),
+			exec("node", [path.resolve(__dirname, "fiveRequests.js")]),
+		])
+			.then((stdout) => {
+				const slowResponses = getResponses(stdout[0]);
+				const fastResponses = getResponses(stdout[1]);
+				expect(slowResponses).toHaveLength(1);
+				expect(fastResponses).toHaveLength(4);
+			});
+	}, 15000);
+
+	it("Multiple ndoes should be able to call a single action.", () => {
+		return Promise.all([
+			exec("node", [path.resolve(__dirname, "fiveRequests.js")]),
+			exec("node", [path.resolve(__dirname, "singleRequest.js")]),
+			exec("node", [path.resolve(__dirname, "worker1.js")]),
+		])
+			.then((stdout) => {
+				const responses = findLines(stdout[2], respondTo);
+				expect(responses).toHaveLength(6);
+			});
+	}, 15000);
+
+	it("Should not have a request or response dequeued until it has been received", () => {
+		return Promise.all([
+			exec("node", [path.resolve(__dirname, "singleRequest.js")]),
+			exec("node", [path.resolve(__dirname, "tooSlowWorker.js")]),
+		])
+			.then((stdout) => {
+				const responses = findLines(stdout[1], "responded");
+				expect(responses).toHaveLength(0);
+				return exec("node", [path.resolve(__dirname, "timeStampedWorker.js")]);
+			})
+			.then(stdout => {
+				const responses = findLines(stdout, "responded");
+				expect(responses).toHaveLength(1);
+				return exec("node", [path.resolve(__dirname, "timeStampedWorker.js")]);
+			})
+			.then(stdout => {
+				const responses = findLines(stdout, "responded");
+				expect(responses).toHaveLength(0);
+			});
+	}, 60000);
+});

--- a/test/integration/amqp/rpc/singleRequest.js
+++ b/test/integration/amqp/rpc/singleRequest.js
@@ -1,0 +1,23 @@
+const {
+	ServiceBroker,
+	Transporters: { AMQP: AmqpTransport }
+} = require("../../../..");
+const AMQP_URL = "amqp://guest:guest@localhost:5672";
+
+const amqpTransporter = new AmqpTransport(AMQP_URL);
+const broker = new ServiceBroker({
+	nodeID: "single-request-nodeID",
+	logger: console,
+	transporter: amqpTransporter,
+});
+
+broker.start();
+
+setTimeout(() => process.exit(1), 10000);
+
+const messageID = process.argv[2] || Date.now();
+
+setTimeout(() => {
+	broker.call("testing.hello", { cmd: "request" + messageID })
+		.then(console.log);
+}, 1000);

--- a/test/integration/amqp/rpc/slowWorker.js
+++ b/test/integration/amqp/rpc/slowWorker.js
@@ -1,0 +1,35 @@
+const {
+	ServiceBroker,
+	Transporters: { AMQP: AmqpTransport }
+} = require("../../../..");
+const AMQP_URL = "amqp://guest:guest@localhost:5672";
+
+const amqpTransporter = new AmqpTransport(AMQP_URL);
+const broker = new ServiceBroker({
+	nodeID: "slow-nodeID",
+	logger: console,
+	transporter: amqpTransporter,
+});
+
+broker.createService({
+	name: "testing",
+	actions: {
+		hello: {
+			params: {
+				cmd: { type: "string" }
+			},
+			handler(ctx) {
+				console.log("slowWorker responding to", ctx.params.cmd);
+				return new Promise((resolve) => {
+					setTimeout(() => {
+						resolve({ msg: ctx.params.cmd, from: "slowWorker" });
+					}, 4000);
+				});
+			},
+		},
+	},
+});
+
+broker.start();
+
+setTimeout(() => process.exit(1), 10000);

--- a/test/integration/amqp/rpc/timeStampedWorker.js
+++ b/test/integration/amqp/rpc/timeStampedWorker.js
@@ -1,0 +1,37 @@
+const {
+	ServiceBroker,
+	Transporters: { AMQP: AmqpTransport }
+} = require("../../../..");
+const AMQP_URL = "amqp://guest:guest@localhost:5672";
+
+const amqpTransporter = new AmqpTransport(AMQP_URL);
+const broker = new ServiceBroker({
+	nodeID: "timestamped-nodeID",
+	logger: console,
+	transporter: amqpTransporter,
+});
+
+broker.createService({
+	name: "testing",
+	actions: {
+		hello: {
+			params: {
+				cmd: { type: "string" }
+			},
+			handler(ctx) {
+				console.log("timestampedWorker responding to", ctx.params.cmd);
+				console.log("received", Date.now());
+				return new Promise((resolve) => {
+					setTimeout(() => {
+						console.log("responded", Date.now());
+  					resolve({ msg: ctx.params.cmd, from: "timestampedWorker" });
+					}, 1000);
+				});
+			},
+		},
+	},
+});
+
+broker.start();
+
+setTimeout(() => process.exit(1), 10000);

--- a/test/integration/amqp/rpc/tooSlowWorker.js
+++ b/test/integration/amqp/rpc/tooSlowWorker.js
@@ -1,0 +1,35 @@
+const {
+	ServiceBroker,
+	Transporters: { AMQP: AmqpTransport }
+} = require("../../../..");
+const AMQP_URL = "amqp://guest:guest@localhost:5672";
+
+const amqpTransporter = new AmqpTransport(AMQP_URL);
+const broker = new ServiceBroker({
+	nodeID: "too-slow-nodeID",
+	logger: console,
+	transporter: amqpTransporter,
+});
+
+broker.createService({
+	name: "testing",
+	actions: {
+		hello: {
+			params: {
+				cmd: { type: "string" }
+			},
+			handler(ctx) {
+				return new Promise((resolve) => {
+					setTimeout(() => {
+						resolve({ msg: ctx.params.cmd, from: "too-slow" });
+						console.log("responded", ctx.params.cmd);
+					}, 9000);
+				});
+			},
+		},
+	},
+});
+
+broker.start();
+
+setTimeout(() => process.exit(1), 8000);

--- a/test/integration/amqp/rpc/worker1.js
+++ b/test/integration/amqp/rpc/worker1.js
@@ -1,0 +1,31 @@
+const {
+	ServiceBroker,
+	Transporters: { AMQP: AmqpTransport }
+} = require("../../../..");
+const AMQP_URL = "amqp://guest:guest@localhost:5672";
+
+const amqpTransporter = new AmqpTransport(AMQP_URL);
+const broker = new ServiceBroker({
+	nodeID: "worker1-nodeID",
+	logger: console,
+	transporter: amqpTransporter,
+});
+
+broker.createService({
+	name: "testing",
+	actions: {
+		hello: {
+			params: {
+				cmd: { type: "string" }
+			},
+			handler(ctx) {
+				console.log("worker1 responding to", ctx.params.cmd);
+				return Promise.resolve({ msg: ctx.params.cmd, from: "worker1" });
+			},
+		},
+	},
+});
+
+broker.start();
+
+setTimeout(() => process.exit(130), 10000);

--- a/test/integration/amqp/rpc/worker2.js
+++ b/test/integration/amqp/rpc/worker2.js
@@ -1,0 +1,31 @@
+const {
+	ServiceBroker,
+	Transporters: { AMQP: AmqpTransport }
+} = require("../../../..");
+const AMQP_URL = "amqp://guest:guest@localhost:5672";
+
+const amqpTransporter = new AmqpTransport(AMQP_URL);
+const broker = new ServiceBroker({
+	nodeID: "worker2-nodeID",
+	logger: console,
+	transporter: amqpTransporter,
+});
+
+broker.createService({
+	name: "testing",
+	actions: {
+		hello: {
+			params: {
+				cmd: { type: "string" }
+			},
+			handler(ctx) {
+				console.log("worker2 responding to", ctx.params.cmd);
+				return Promise.resolve({ msg: ctx.params.cmd, from: "worker2" });
+			},
+		},
+	},
+});
+
+broker.start();
+
+setTimeout(() => process.exit(1), 10000);

--- a/test/integration/amqp/util.js
+++ b/test/integration/amqp/util.js
@@ -1,0 +1,38 @@
+/* istanbul ignore next*/
+const debugExec = (cmd, args=[]) =>
+	new Promise(function (resolve, reject) {
+		require("child_process")
+			.spawn(cmd, args, { stdio: "inherit", shell: true })
+			.on("exit", resolve)
+			.on("error", reject);
+	});
+
+/* istanbul ignore next*/
+const exec = (cmd, args=[]) =>
+	new Promise(function (resolve, reject) {
+		let data = "";
+		const process = require("child_process")
+			.spawn(cmd, args, { stdio: "pipe", shell: true });
+
+		process
+			.stdout.on("data", function (chunk) {
+				data += chunk;
+			});
+		process
+			.on("exit", () => resolve(data))
+			.on("error", () => reject(data));
+	});
+
+/* istanbul ignore next*/
+const callIn = (cb, timeout) =>
+	new Promise(res => {
+		setTimeout(() => {
+			cb().then(res);
+		}, timeout);
+	});
+
+module.exports = {
+	exec,
+	debugExec,
+	callIn,
+};

--- a/test/unit/service-broker.spec.js
+++ b/test/unit/service-broker.spec.js
@@ -231,6 +231,11 @@ describe("Test option resolvers", () => {
 			expect(trans).toBeInstanceOf(Transporters.NATS);
 		});
 
+		it("should resolve AMQPTransporter from connection string", () => {
+			let trans = broker._resolveTransporter("amqp://localhost:5672");
+			expect(trans).toBeInstanceOf(Transporters.AMQP);
+		});
+
 		it("should resolve MQTTTransporter from connection string", () => {
 			let trans = broker._resolveTransporter("mqtt://localhost");
 			expect(trans).toBeInstanceOf(Transporters.MQTT);
@@ -256,6 +261,19 @@ describe("Test option resolvers", () => {
 			let trans = broker._resolveTransporter({ options });
 			expect(trans).toBeInstanceOf(Transporters.NATS);
 			expect(trans.opts).toEqual({"nats": {"preserveBuffers": true, "url": "nats://localhost:4222"}});
+		});
+
+		it("should resolve AMQPTransporter from obj", () => {
+			let options = { amqp: { url: "amqp://localhost" } };
+			let trans = broker._resolveTransporter({ type: "AMQP", options });
+			expect(trans).toBeInstanceOf(Transporters.AMQP);
+			expect(trans.opts).toEqual({
+				amqp: {
+					prefetch: 1,
+					eventTimeToLive: 5000,
+					url: "amqp://localhost"
+				},
+			});
 		});
 
 		it("should resolve NATSTransporter from obj", () => {

--- a/test/unit/transporters/amqp.spec.js
+++ b/test/unit/transporters/amqp.spec.js
@@ -1,0 +1,412 @@
+const ServiceBroker = require("../../../src/service-broker");
+const Transit = require("../../../src/transit");
+const { PacketInfo } = require("../../../src/packets");
+
+jest.mock("amqplib");
+
+let Amqp = require("amqplib");
+Amqp.connect = jest.fn(() => {
+	let connectionOnCallbacks = {};
+	const ref = {};
+	ref.connection = {
+		on: jest.fn((event, cb) => {
+			connectionOnCallbacks[event] = cb;
+			return ref.connection;
+		}),
+		close: jest.fn(),
+		connectionOnCallbacks,
+		createChannel: jest.fn(() => {
+			let channelOnCallbacks = {};
+			let ref = {};
+			ref.channel = {
+				prefetch: jest.fn(),
+				on: jest.fn((event, cb) => {
+					channelOnCallbacks[event] = cb;
+					return ref.channel;
+				}),
+				unbindQueue: jest.fn(() => Promise.resolve()),
+				bindQueue: jest.fn(() => Promise.resolve()),
+				assertExchange: jest.fn(() => Promise.resolve()),
+				assertQueue: jest.fn(() => Promise.resolve()),
+				consume: jest.fn(() => Promise.resolve()),
+				close: jest.fn(() => Promise.resolve()),
+
+				publish: jest.fn(),
+				ack: jest.fn(),
+				sendToQueue: jest.fn(),
+				channelOnCallbacks,
+			};
+
+			return Promise.resolve(ref.channel);
+		}),
+	};
+	return Promise.resolve(ref.connection);
+});
+
+const AmqpTransporter = require("../../../src/transporters/amqp");
+
+
+describe("Test AmqpTransporter constructor", () => {
+
+	it("check constructor with string param", () => {
+		let transporter = new AmqpTransporter("amqp://localhost");
+		expect(transporter).toBeDefined();
+		expect(transporter.opts).toEqual({
+			amqp: { url: "amqp://localhost", prefetch: 1, eventTimeToLive: 5000 }
+		});
+		expect(transporter.connected).toBe(false);
+		expect(transporter.channel).toBeNull();
+		expect(transporter.connection).toBeNull();
+		expect(transporter.bindings).toHaveLength(0);
+	});
+
+	it("check constructor with options", () => {
+		let opts = { amqp: { url: "amqp://localhost", prefetch: 3, eventTimeToLive: 10000 } };
+		let transporter = new AmqpTransporter(opts);
+		expect(transporter.opts).toEqual(opts);
+	});
+});
+
+describe("Test AmqpTransporter connect & disconnect", () => {
+	let broker = new ServiceBroker();
+	let transit = new Transit(broker);
+	let msgHandler = jest.fn();
+	let transporter;
+
+	beforeEach(() => {
+		transporter = new AmqpTransporter({ amqp: { url: "amqp://localhost", prefetch: 3 } });
+		transporter.init(transit, msgHandler);
+	});
+
+	it("check connect", () => {
+		return transporter.connect().then(() => {
+			expect(transporter.connection).toBeDefined();
+			expect(transporter.connection.on).toHaveBeenCalledTimes(4);
+			expect(transporter.connection.on).toHaveBeenCalledWith("error", jasmine.any(Function));
+			expect(transporter.connection.on).toHaveBeenCalledWith("close", jasmine.any(Function));
+			expect(transporter.connection.on).toHaveBeenCalledWith("blocked", jasmine.any(Function));
+			expect(transporter.connection.on).toHaveBeenCalledWith("unblocked", jasmine.any(Function));
+			expect(transporter.channel).toBeDefined();
+			expect(transporter.channel.on).toHaveBeenCalledTimes(4);
+			expect(transporter.channel.on).toHaveBeenCalledWith("error", jasmine.any(Function));
+			expect(transporter.channel.on).toHaveBeenCalledWith("close", jasmine.any(Function));
+			expect(transporter.channel.on).toHaveBeenCalledWith("return", jasmine.any(Function));
+			expect(transporter.channel.on).toHaveBeenCalledWith("drain", jasmine.any(Function));
+			expect(transporter.channel.prefetch).toHaveBeenCalledTimes(1);
+			expect(transporter.channel.prefetch).toHaveBeenCalledWith(3);
+		});
+	});
+
+	it("check onConnected after connect", () => {
+		transporter.onConnected = jest.fn(() => Promise.resolve());
+		return transporter.connect().then(() => {
+			expect(transporter.onConnected).toHaveBeenCalledTimes(1);
+			expect(transporter.onConnected).toHaveBeenCalledWith();
+		});
+	});
+
+	it("check disconnect", () => {
+		transporter.bindings = [["queue1", "exchange1", ""], ["queue2", "exchange2", ""]];
+		return transporter.connect().then(() => {
+			let chanCloseCb = transporter.channel.close;
+			let chanUnbindCb = transporter.channel.unbindQueue;
+			let conCloseCb = transporter.connection.close;
+			let bindings = transporter.bindings;
+			transporter.disconnect()
+				.then(() => {
+					expect(transporter.channel).toBeNull();
+					expect(transporter.connection).toBeNull();
+					expect(chanCloseCb).toHaveBeenCalledTimes(1);
+					expect(conCloseCb).toHaveBeenCalledTimes(1);
+
+					expect(chanUnbindCb).toHaveBeenCalledTimes(bindings.length);
+					for (let binding of bindings) {
+						expect(chanUnbindCb).toHaveBeenCalledWith(...binding);
+					}
+				});
+		});
+	});
+});
+
+describe("Test AmqpTransporter subscribe", () => {
+	let transporter;
+	let msgHandler;
+
+	beforeEach(() => {
+		msgHandler = jest.fn();
+		transporter = new AmqpTransporter({ amqp: { url: "amqp://localhost", eventTimeToLive: 3000 }});
+		transporter.init(new Transit(new ServiceBroker({ namespace: "TEST", nodeID: "node" })), msgHandler);
+		return transporter.connect();
+	});
+
+	it("check RES subscription", () => {
+		return transporter.subscribe("RES", "node")
+			.then(() => {
+				expect(transporter.channel.assertQueue).toHaveBeenCalledTimes(1);
+				expect(transporter.channel.consume).toHaveBeenCalledTimes(1);
+				expect(transporter.channel.assertQueue)
+					.toHaveBeenCalledWith("MOL-TEST.RES.node", {});
+				expect(transporter.channel.consume)
+					.toHaveBeenCalledWith("MOL-TEST.RES.node", jasmine.any(Function), { noAck: true });
+
+				const consumeCb = transporter.channel.consume.mock.calls[0][1];
+				consumeCb({ content: new Buffer("data") });
+
+				expect(msgHandler).toHaveBeenCalledTimes(1);
+				expect(transporter.channel.ack).toHaveBeenCalledTimes(0);
+			});
+	});
+
+	it("check INFO.nodeID subscription", () => {
+		transporter.getTopicName = () => "MOL-TEST.INFO.node";
+		return transporter.subscribe("RES", "node")
+			.then(() => {
+				expect(transporter.channel.assertQueue).toHaveBeenCalledTimes(1);
+				expect(transporter.channel.consume).toHaveBeenCalledTimes(1);
+				expect(transporter.channel.assertQueue)
+					.toHaveBeenCalledWith("MOL-TEST.INFO.node", {});
+				expect(transporter.channel.consume)
+					.toHaveBeenCalledWith("MOL-TEST.INFO.node", jasmine.any(Function), { noAck: true });
+
+				const consumeCb = transporter.channel.consume.mock.calls[0][1];
+				consumeCb({ content: new Buffer("data") });
+
+				expect(msgHandler).toHaveBeenCalledTimes(1);
+				expect(transporter.channel.ack).toHaveBeenCalledTimes(0);
+			});
+	});
+
+	it("check REQ subscription", () => {
+		const mockServices = [
+			{ schema: { name: "empty" } },
+			{
+				schema: {
+					name: "example1",
+					actions: {
+						testing: {},
+						hello: {},
+					}
+				}
+			},
+			{
+				schema: {
+					name: "example2",
+					actions: { world: {} },
+				}
+			}
+		];
+
+		return transporter._makeServiceSpecificSubscriptions(mockServices)
+			.then(() => {
+				expect(transporter.channel.assertQueue).toHaveBeenCalledTimes(3);
+				expect(transporter.channel.consume).toHaveBeenCalledTimes(3);
+				expect(transporter.channel.assertQueue)
+					.toHaveBeenCalledWith("MOL-TEST.REQ.example2.world", {});
+				expect(transporter.channel.assertQueue)
+					.toHaveBeenCalledWith("MOL-TEST.REQ.example1.hello", {});
+				expect(transporter.channel.assertQueue)
+					.toHaveBeenCalledWith("MOL-TEST.REQ.example1.testing", {});
+
+				expect(transporter.channel.consume)
+					.toHaveBeenCalledWith("MOL-TEST.REQ.example2.world", jasmine.any(Function));
+				expect(transporter.channel.consume)
+					.toHaveBeenCalledWith("MOL-TEST.REQ.example1.hello", jasmine.any(Function));
+				expect(transporter.channel.consume)
+					.toHaveBeenCalledWith("MOL-TEST.REQ.example1.testing", jasmine.any(Function));
+
+				const consumeCb = transporter.channel.consume.mock.calls[0][1];
+				consumeCb({ content: new Buffer("data") });
+
+				expect(msgHandler).toHaveBeenCalledTimes(1);
+				expect(transporter.channel.ack).toHaveBeenCalledTimes(1);
+			});
+	});
+
+	it("check EVENT subscription", () => {
+		return transporter.subscribe("EVENT")
+			.then(() => {
+				expect(transporter.channel.assertQueue).toHaveBeenCalledTimes(1);
+				expect(transporter.channel.assertExchange).toHaveBeenCalledTimes(1);
+				expect(transporter.channel.bindQueue).toHaveBeenCalledTimes(1);
+				expect(transporter.channel.consume).toHaveBeenCalledTimes(1);
+
+				expect(transporter.channel.assertQueue)
+					.toHaveBeenCalledWith("MOL-TEST.EVENT.node", { messageTtl: 3000 }); // use ttl option
+				expect(transporter.channel.assertExchange)
+					.toHaveBeenCalledWith("MOL-TEST.EVENT", "fanout");
+				expect(transporter.channel.bindQueue)
+					.toHaveBeenCalledWith("MOL-TEST.EVENT.node", "MOL-TEST.EVENT", "");
+				expect(transporter.channel.consume)
+					.toHaveBeenCalledWith(
+						"MOL-TEST.EVENT.node",
+						jasmine.any(Function),
+						{ noAck: true }
+					);
+
+				const consumeCb = transporter.channel.consume.mock.calls[0][1];
+				consumeCb({ content: new Buffer("data") });
+
+				expect(msgHandler).toHaveBeenCalledTimes(1);
+				expect(transporter.channel.ack).toHaveBeenCalledTimes(0);
+			});
+	});
+
+	["DISCOVER", "DISCONNECT", "INFO", "HEARTBEAT"].forEach(type => {
+		it(`check ${type} subscription`, () => {
+			return transporter.subscribe(type)
+				.then(() => {
+					expect(transporter.channel.assertQueue).toHaveBeenCalledTimes(1);
+					expect(transporter.channel.assertExchange).toHaveBeenCalledTimes(1);
+					expect(transporter.channel.bindQueue).toHaveBeenCalledTimes(1);
+					expect(transporter.channel.consume).toHaveBeenCalledTimes(1);
+
+					expect(transporter.channel.assertQueue)
+						.toHaveBeenCalledWith(`MOL-TEST.${type}.node`, { messageTtl: 5000 });
+					expect(transporter.channel.assertExchange)
+						.toHaveBeenCalledWith(`MOL-TEST.${type}`, "fanout");
+					expect(transporter.channel.bindQueue)
+						.toHaveBeenCalledWith(`MOL-TEST.${type}.node`, `MOL-TEST.${type}`, "");
+					expect(transporter.channel.consume)
+						.toHaveBeenCalledWith(
+							`MOL-TEST.${type}.node`,
+							jasmine.any(Function),
+							{ noAck: true }
+						);
+
+					const consumeCb = transporter.channel.consume.mock.calls[0][1];
+					consumeCb({ content: new Buffer("data") });
+
+					expect(msgHandler).toHaveBeenCalledTimes(1);
+					expect(transporter.channel.ack).toHaveBeenCalledTimes(0);
+				});
+		});
+	});
+});
+
+describe("Test AmqpTransporter publish", () => {
+	let transporter;
+	let msgHandler;
+
+	const fakeTransit = {
+		nodeID: "node1",
+		serialize: jest.fn(msg => JSON.stringify(msg))
+	};
+
+	beforeEach(() => {
+		msgHandler = jest.fn();
+		transporter = new AmqpTransporter({ amqp: { url: "amqp://localhost", eventTimeToLive: 3000 }});
+		transporter.init(new Transit(new ServiceBroker({ namespace: "TEST" })), msgHandler);
+		return transporter.connect();
+	});
+
+	it("check INFO.node publish", () => {
+		const packet = new PacketInfo(fakeTransit, "node2", {});
+		return transporter.publish(packet)
+			.then(() => {
+				expect(transporter.channel.sendToQueue).toHaveBeenCalledTimes(1);
+				expect(transporter.channel.sendToQueue).toHaveBeenCalledWith(
+					"MOL-TEST.INFO.node2",
+					Buffer.from(JSON.stringify({"sender": "node1"}))
+				);
+			});
+	});
+
+	// The following tests mock a packet for ease of testing.
+	it("check REQ publish", () => {
+		transporter.getTopicName = () => `${transporter.prefix}.REQ`;
+		const packet = {
+			type: "REQ",
+			serialize: () => JSON.stringify({ fake: "payload" }),
+			payload: {
+				action: "echo"
+			}
+		};
+		return transporter.publish(packet)
+			.then(() => {
+				expect(transporter.channel.sendToQueue).toHaveBeenCalledTimes(1);
+				expect(transporter.channel.sendToQueue).toHaveBeenCalledWith(
+					"MOL-TEST.REQ.echo",
+					Buffer.from(packet.serialize())
+				);
+			});
+	});
+
+	it("check RES publish", () => {
+		transporter.getTopicName = () => `${transporter.prefix}.RES.node`;
+		const packet = {
+			type: "RES",
+			serialize: () => JSON.stringify({ fake: "payload" }),
+		};
+		return transporter.publish(packet)
+			.then(() => {
+				expect(transporter.channel.sendToQueue).toHaveBeenCalledTimes(1);
+				expect(transporter.channel.sendToQueue).toHaveBeenCalledWith(
+					"MOL-TEST.RES.node",
+					Buffer.from(packet.serialize())
+				);
+			});
+	});
+
+	["EVENT", "DISCOVER", "HEARTBEAT", "DISCONNECT"].forEach((type) => {
+		it(`check ${type} publish`, () => {
+			transporter.getTopicName = () => `${transporter.prefix}.${type}.node`;
+			const packet = {
+				type,
+				serialize: () => JSON.stringify({ fake: "payload" }),
+			};
+			return transporter.publish(packet)
+				.then(() => {
+					expect(transporter.channel.publish).toHaveBeenCalledTimes(1);
+					expect(transporter.channel.publish).toHaveBeenCalledWith(
+						`MOL-TEST.${type}.node`,
+						"",
+						Buffer.from(packet.serialize())
+					);
+				});
+		});
+	});
+
+	it("check INFO publish", () => {
+		transporter.getTopicName = () => `${transporter.prefix}.INFO`;
+		transporter._makeServiceSpecificSubscriptions = jest.fn(() => Promise.resolve());
+		const mockServices = [
+			{ schema: { name: "empty" } },
+			{
+				schema: {
+					name: "example1",
+					actions: {
+						testing: {},
+						hello: {},
+					}
+				}
+			},
+			{
+				schema: {
+					name: "example2",
+					actions: { world: {} },
+				}
+			}
+		];
+		const packet = {
+			type: "INFO",
+			serialize: () => JSON.stringify({ fake: "payload" }),
+			transit: {
+				broker: {
+					services: mockServices
+				}
+			}
+		};
+		return transporter.publish(packet)
+			.then(() => {
+				expect(transporter.channel.publish).toHaveBeenCalledTimes(1);
+				expect(transporter.channel.publish).toHaveBeenCalledWith(
+					"MOL-TEST.INFO",
+					"",
+					Buffer.from(packet.serialize())
+				);
+
+				expect(transporter._makeServiceSpecificSubscriptions).toHaveBeenCalledTimes(1);
+				expect(transporter._makeServiceSpecificSubscriptions).toHaveBeenCalledWith(mockServices);
+			});
+	});
+});


### PR DESCRIPTION
Resolves #1 

This Transporter is a bit more involved than some of the others because it needs to treat some packet types specially. Broadcasted packets need to use AMQP exchanges, but targeted packets only need a queue.  This implementation also deals with Requests a bit differently than other Transporters do. Each action has its own work queue that multiple nodes can pull messages from. This means that messages are less likely to be lost (due to crashes / etc). Each node will consume more messages when it has an availability. The number of messages that can be handled concurrently by a node can be specified with the `amqp.prefetch` option.

Requests and Responses don’t have a set time-to-live, but all other packet types do. Currently events’ time-to-live can be configured using the `amqp.eventTimeToLive` option, but the other types are hardcoded at 5 seconds.


**Transporter Options:**
```js
new AmqpTransporter({
  amqp: {
    url: "amqp://guest:guest@localhost:5672",
    eventTimeToLive: 5000,
    prefetch: 1   
  }
});
```

### AMQP Transport behaviour by topic

![AMQP Transporter diagram](https://i.imgur.com/g6ppJqx.png "AMQP Transporter diagram")

I’ve included unit tests and some integration tests. The integration tests are skipped right now because they require an amqp server to be running at `amqp://guest:guest@localhost:5672`. Let me know if I should remove them. :+1: 

Other notes:
- I don’t have a ton of experience with JSDoc, don’t hesitate to let me know if I can improve them. 
- I tried to to use `istanbul ignore` the same way as in other files, but let me know if I should change anything. 