### PR TITLE
Internal service & removed nodeID is null logic

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,3 +10,5 @@ indent_size = 4
 
 [*.md]
 trim_trailing_whitespace = false
+indent_style = space
+indent_size = 4

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -22,7 +22,7 @@
 			"type": "node",
 			"request": "launch",
 			"name": "Launch demo:transporter",
-			"program": "${workspaceRoot}\\examples\\transporter\\server1.js",
+			"program": "${workspaceRoot}\\examples\\transporter\\index.js",
 			"cwd": "${workspaceRoot}\\examples\\transporter"
 		},
 		{

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,33 +1,29 @@
 # Roadmap
 
-## v0.9.x
-- [x] multi broker.call (array & object)
-- [x] namespace support
-- [x] better custom logger support
-- [x] service hot-reload
-------------------------------
+## v0.11.x
 
-## v0.10.x
 - [ ] broker plugin system (adopt middleware feature)
 - [ ] official Zipkin tracer service
 - [ ] add lru features to Memory and Redis cachers
 - [ ] official services
-	- [ ] `moleculer-auth` for authentication
-	- [ ] `moleculer-twitter` Twitter client
-	- [ ] `moleculer-slack` Slack client
-	- [ ] `moleculer-stripe`
+  - [ ] `moleculer-auth` for authentication
+  - [ ] `moleculer-twitter` Twitter client
+  - [ ] `moleculer-slack` Slack client
+  - [ ] `moleculer-stripe`
 - [ ] key-value store adapter
-	- [ ] couchdb
-	- [ ] couchbase
-	- [ ] dynamodb
-	- [ ] redis
+  - [ ] couchdb
+  - [ ] couchbase
+  - [ ] dynamodb
+  - [ ] redis
 
 ------------------------------
 
 ## v1.0.x
+
 It will be the first stable production-ready release. Afterwards the version numbers should follow semver versioning.
 
 ## Others in the future
+
 - [ ] more [offical examples](https://github.com/ice-services/moleculer-examples)
 - [ ] Docker examples
 - [ ] RabbitMQ transporter
@@ -35,6 +31,6 @@ It will be the first stable production-ready release. Afterwards the version num
 - [ ] compress transfer
 - [ ] crypt transfer
 - [ ] Other transporters
-	- [ ] TCP with UDP
-	- [ ] websocket
-	- [ ] [AutobahnJS](http://autobahn.ws/js/) [server](https://github.com/Orange-OpenSource/wamp.rt) or [server in go](https://github.com/jcelliott/turnpike)
+  - [ ] TCP with UDP
+  - [ ] websocket
+  - [ ] [AutobahnJS](http://autobahn.ws/js/) [server](https://github.com/Orange-OpenSource/wamp.rt) or [server in go](https://github.com/jcelliott/turnpike)

--- a/dev/dev.js
+++ b/dev/dev.js
@@ -8,18 +8,7 @@ let { MoleculerError } = require("../src/errors");
 let broker1 = new ServiceBroker({
 	nodeID: "node1",
 	logger: true,
-	logLevel: "debug",
-	requestTimeout: 5000,
-	requestRetry: 3,
-	transporter: "NATS",
-	//cacher: "redis://localhost",
-	serializer: "JSON",
-	circuitBreaker: {
-		enabled: true
-	},
-	registry: {
-		//preferLocal: false
-	}
+	transporter: "NATS"
 });
 
 //broker1.loadService("./examples/math.service");
@@ -29,40 +18,15 @@ let broker1 = new ServiceBroker({
 let broker2 = new ServiceBroker({
 	nodeID: "node2",
 	logger: true,
-	logLevel: "info",
-	transporter: "NATS",
-	/*cacher: {
-		type: "Redis",
-		options: {
-			redis: {
-				host: "localhost",
-				db: 3
-			}
-		}
-	},*/
-	serializer: "JSON",
-	statistics: true
+	transporter: "NATS"
 });
-/*
-broker2.createService({
-	name: "devil",
-	actions: {
-		danger(ctx) {
-			throw new MoleculerError("Run!", 666, null, { a: 100 });
-		}
-	}
-});*/
+
 broker2.loadService("./examples/math.service");
-//broker2.loadService("./examples/file.service");
-broker2.loadService("./examples/test.service");
-broker2.loadService("./examples/user.service");
-broker2.loadService("./examples/user.v1.service");
 
 broker1.Promise.resolve()
 	.then(() => broker1.start())
 	.then(() => broker2.start())
 	.delay(500)
-	.then(() => broker1.call("$node.actions", { onlyLocal: true }, { nodeID: "node1" }))
 	//.then(res => console.log(res))
 	.catch(err => console.log(err))
 	.then(() => broker1.repl());

--- a/dev/dev.js
+++ b/dev/dev.js
@@ -8,6 +8,7 @@ let { MoleculerError } = require("../src/errors");
 let broker1 = new ServiceBroker({
 	nodeID: "node1",
 	logger: true,
+	logLevel: "debug",
 	transporter: "NATS"
 });
 
@@ -18,6 +19,7 @@ let broker1 = new ServiceBroker({
 let broker2 = new ServiceBroker({
 	nodeID: "node2",
 	logger: true,
+	logLevel: "debug",
 	transporter: "NATS"
 });
 
@@ -27,6 +29,7 @@ broker1.Promise.resolve()
 	.then(() => broker1.start())
 	.then(() => broker2.start())
 	.delay(500)
-	//.then(res => console.log(res))
-	.catch(err => console.log(err))
+	.then(() => broker1.call("math.add", { a: 7, b: 3 }))
+	.then(res => broker1.logger.info("Result:", res))
+	.catch(err => broker1.logger.error(err))
 	.then(() => broker1.repl());

--- a/examples/transporter/server1.js
+++ b/examples/transporter/server1.js
@@ -13,7 +13,8 @@ let broker = new ServiceBroker({
 	logger: console,
 	logLevel: "info",
 	requestTimeout: 5 * 1000,
-	serializer: "JSON"
+	serializer: "JSON",
+	metrics: true,
 	//requestRetry: 3
 });
 
@@ -30,30 +31,26 @@ broker.on("TEST2", a => {
 Promise.resolve()
 	.then(delay(1000))
 
-	.then(() => {
+	/*.then(() => {
 		broker.call("v2.users.find").then(res => {
-			broker.logger.info("[server-1] Success!", res.length);
+			broker.logger.info("Success!", res.length);
 		}).catch(err => {
-			broker.logger.error("[server-1] Error!", err.message);
+			broker.logger.error("Error!", err.message);
 		});
 
-	})
-/*
-.then(() => {
-	
-	setInterval(() => {
-		let startTime = Date.now();
-		broker.call("posts.find").then((posts) => {
-			console.log("[server-1] Posts: ", posts.length, ", Time:", Date.now() - startTime, "ms");
-		}).catch(err => {
-			console.error("[server-1] Error!", err.message);
-		});	
-	}, 8000);
-	
-})
-*/
+	})*/
+
 	.then(() => {
-	//broker.call("users.dangerous").catch(err => console.error(err));
+
+		setInterval(() => {
+			let startTime = Date.now();
+			broker.call("posts.find").then((posts) => {
+				broker.logger.info("Posts: ", posts.length, ", Time:", Date.now() - startTime, "ms");
+			}).catch(err => {
+				broker.logger.error("Error!", err.message);
+			});
+		}, 4000);
+
 	})
 
 	.then(() => {

--- a/examples/transporter/server2.js
+++ b/examples/transporter/server2.js
@@ -12,12 +12,20 @@ let broker = new ServiceBroker({
 	transporter: "NATS",
 	logger: console,
 	logLevel: "info",
-	serializer: "JSON"
+	serializer: "JSON",
+	metrics: true,
 });
 
 //broker.loadService(__dirname + "/../post.service");
 broker.loadService(__dirname + "/../user.service");
+/*
+broker.on("metrics.trace.span.start", payload => {
+	broker.logger.info("metrics.trace.span.start", payload);
+});
 
+broker.on("metrics.trace.span.finish", payload => {
+	broker.logger.info("metrics.trace.span.finish", payload);
+});*/
 
 broker.start();
 let c = 1;
@@ -32,7 +40,7 @@ Promise.resolve()
 		let startTime = Date.now();
 
 		broker.call("posts.find").then((posts) => {
-			broker.logger.info("[server-2] Posts: ", posts.length, ", Time:", Date.now() - startTime, "ms");
+			broker.logger.info("Posts: ", posts.length, ", Time:", Date.now() - startTime, "ms");
 		})
 			.catch(err => broker.logger.error(err));
 	})
@@ -44,5 +52,5 @@ Promise.resolve()
 			//process.exit();
 			}
 
-		}, 10 * 1000);
+		}, 5 * 1000);
 	});

--- a/index.d.ts
+++ b/index.d.ts
@@ -86,7 +86,7 @@ declare interface BrokerOptions {
 	metrics?: Boolean;
 	metricsRate?: Number;
 	statistics?: Boolean;
-	internalActions?: Boolean;
+	internalServices?: Boolean;
 
 	ServiceFactory?: Service;
 	ContextFactory?: Context;

--- a/index.d.ts
+++ b/index.d.ts
@@ -215,10 +215,8 @@ declare class ServiceBroker {
 	emitLocal(eventName: String, payload?: any, sender?: String);
 
 	MOLECULER_VERSION: String;
-	LOCAL_NODE_ID: any;
 
 	static MOLECULER_VERSION: String;
-	static LOCAL_NODE_ID: any;
 	static defaultConfig: BrokerOptions;
 }
 

--- a/src/context.js
+++ b/src/context.js
@@ -12,7 +12,7 @@ const { RequestSkippedError } = require("./errors");
 
 /**
  * Context class for action calls
- * 
+ *
  * @property {String} id - Context ID
  * @property {ServiceBroker} broker - Broker instance
  * @property {Action} action - Action definition
@@ -20,23 +20,23 @@ const { RequestSkippedError } = require("./errors");
  * @property {String} parentID - Parent Context ID
  * @property {Boolean} metrics - Need send metrics events
  * @property {Number} [level=1] - Level of context
- * 
+ *
  * @class Context
  */
 class Context {
 
 	/**
 	 * Creates an instance of Context.
-	 * 
+	 *
 	 * @param {ServiceBroker} broker - Broker instance
-	 * @param {Action} action - Action definition 
-	 * 
+	 * @param {Action} action - Action definition
+	 *
 	 * @example
 	 * let ctx = new Context(broker, action);
-	 * 
+	 *
 	 * @example
 	 * let ctx2 = new Context(broker, action);
-	 * 
+	 *
 	 * @memberOf Context
 	 */
 	constructor(broker, action) {
@@ -44,7 +44,7 @@ class Context {
 
 		this.broker = broker;
 		this.action = action;
-		this.nodeID = null;
+		this.nodeID = broker ? broker.nodeID : null;
 		this.parentID = null;
 		this.callerNodeID = null;
 
@@ -73,10 +73,10 @@ class Context {
 
 	/**
 	 * Set params of context
-	 * 
+	 *
 	 * @param {Object} newParams
 	 * @param {Boolean} cloning
-	 * 
+	 *
 	 * @memberOf Context
 	 */
 	setParams(newParams, cloning = false) {
@@ -88,15 +88,15 @@ class Context {
 
 	/**
 	 * Call an other action. It will be create a sub-context.
-	 * 
+	 *
 	 * @param {String} actionName
 	 * @param {Object?} params
 	 * @param {Object?} opts
 	 * @returns {Promise}
-	 * 
+	 *
 	 * @example <caption>Call an other service with params & options</caption>
 	 * ctx.call("posts.get", { id: 12 }, { timeout: 1000 });
-	 * 
+	 *
 	 * @memberOf Context
 	 */
 	call(actionName, params, opts = {}) {
@@ -118,14 +118,14 @@ class Context {
 
 	/**
 	 * Call a global event (with broker.emit).
-	 * 
+	 *
 	 * @param {String} eventName
 	 * @param {any} data
 	 * @returns
-	 * 
+	 *
 	 * @example
 	 * ctx.emit("user.created", { entity: user, creator: ctx.meta.user });
-	 * 
+	 *
 	 * @memberOf Context
 	 */
 	emit(eventName, data) {
@@ -134,9 +134,9 @@ class Context {
 
 	/**
 	 * Send start event to metrics system.
-	 * 
+	 *
 	 * @param {boolean} emitEvent
-	 * 
+	 *
 	 * @private
 	 * @memberOf Context
 	 */
@@ -161,7 +161,7 @@ class Context {
 			if (this.parentID)
 				payload.parent = this.parentID;
 
-			payload.nodeID = this.broker.nodeID;
+			payload.nodeID = this.nodeID;
 			if (this.callerNodeID)
 				payload.callerNodeID = this.callerNodeID;
 
@@ -171,10 +171,10 @@ class Context {
 
 	/**
 	 * Send finish event to metrics system.
-	 * 	   
+	 *
 	 * @param {Error} error
 	 * @param {boolean} emitEvent
-	 * 
+	 *
 	 * @private
 	 * @memberOf Context
 	 */
@@ -204,7 +204,7 @@ class Context {
 			if (this.parentID)
 				payload.parent = this.parentID;
 
-			payload.nodeID = this.broker.nodeID;
+			payload.nodeID = this.nodeID;
 			if (this.callerNodeID)
 				payload.callerNodeID = this.callerNodeID;
 

--- a/src/internals.js
+++ b/src/internals.js
@@ -1,0 +1,107 @@
+/*
+ * moleculer
+ * Copyright (c) 2017 Ice Services (https://github.com/ice-services/moleculer)
+ * MIT Licensed
+ */
+
+"use strict";
+
+const _ = require("lodash");
+
+module.exports = function(broker) {
+	const schema = {
+		name: "$node",
+
+		actions: {
+			list: {
+				cache: false,
+				handler() {
+					let res = [];
+					const localNode = this.broker.transit.getNodeInfo();
+					localNode.id = this.broker.nodeID;
+					localNode.local = true;
+					localNode.available = true;
+					res.push(localNode);
+
+					this.broker.transit.nodes.forEach(node => {
+						//res.push(pick(node, ["nodeID", "available"]));
+						res.push(node);
+					});
+
+					return res;
+				}
+			},
+
+			services: {
+				cache: false,
+				params: {
+					onlyLocal: { type: "boolean", optional: true },
+					skipInternal: { type: "boolean", optional: true },
+					withActions: { type: "boolean", optional: true }
+				},
+				handler(ctx) {
+					let res = [];
+
+					const services = this.broker.serviceRegistry.getServiceList(ctx.params);
+
+					services.forEach(svc => {
+						let item = res.find(o => o.name == svc.name && o.version == svc.version);
+						if (item) {
+							item.nodes.push(svc.nodeID || this.broker.nodeID);
+							// Merge services
+							_.forIn(svc.actions, (action, name) => {
+								if (action.protected === true) return;
+
+								if (!item.actions[name])
+									item.actions[name] = _.omit(action, ["handler", "service"]);
+							});
+
+						} else {
+							item = _.pick(svc, ["name", "version", "settings"]);
+							item.nodes = [svc.nodeID || this.broker.nodeID];
+							item.actions = {};
+							_.forIn(svc.actions, (action, name) => {
+								if (action.protected === true) return;
+
+								item.actions[name] = _.omit(action, ["handler", "service"]);
+							});
+							res.push(item);
+						}
+					});
+
+					return res;
+				}
+			},
+
+			actions: {
+				cache: false,
+				params: {
+					onlyLocal: { type: "boolean", optional: true },
+					skipInternal: { type: "boolean", optional: true },
+					withEndpoints: { type: "boolean", optional: true }
+				},
+				handler(ctx) {
+					return this.broker.serviceRegistry.getActionList(ctx.params);
+				}
+			},
+
+			health: {
+				cache: false,
+				handler() {
+					return this.broker.getNodeHealthInfo();
+				}
+			}
+		}
+	};
+
+	if (broker.statistics) {
+		schema.actions.stats = {
+			cache: false,
+			handler() {
+				return this.broker.statistics.snapshot();
+			}
+		};
+	}
+
+	return schema;
+};

--- a/src/service-broker.js
+++ b/src/service-broker.js
@@ -591,7 +591,8 @@ class ServiceBroker {
 	 * @memberOf ServiceBroker
 	 */
 	registerInternalActions() {
-		this.serviceRegistry.registerService(LOCAL_NODE_ID, {
+		this.createService(require("./internals")(this));
+		/*this.serviceRegistry.registerService(LOCAL_NODE_ID, {
 			name: "$node",
 			settings: {}
 		});
@@ -665,7 +666,7 @@ class ServiceBroker {
 			addAction("$node.stats", () => {
 				return this.statistics.snapshot();
 			});
-		}
+		}*/
 	}
 
 	/**

--- a/src/service-broker.js
+++ b/src/service-broker.js
@@ -64,7 +64,7 @@ const defaultConfig = {
 	metrics: false,
 	metricsRate: 1,
 	statistics: false,
-	internalActions: true,
+	internalServices: true,
 
 	// ServiceFactory: null,
 	// ContextFactory: null
@@ -150,7 +150,7 @@ class ServiceBroker {
 		this.getNodeHealthInfo = () => healthInfo(this);
 
 		// Register internal actions
-		if (this.options.internalActions)
+		if (this.options.internalServices)
 			this.registerInternalServices();
 
 		// Graceful exit

--- a/src/service-broker.js
+++ b/src/service-broker.js
@@ -66,7 +66,7 @@ const defaultConfig = {
 	metrics: false,
 	metricsRate: 1,
 	statistics: false,
-	internalActions: true
+	internalActions: true,
 
 	// ServiceFactory: null,
 	// ContextFactory: null
@@ -153,7 +153,7 @@ class ServiceBroker {
 
 		// Register internal actions
 		if (this.options.internalActions)
-			this.registerInternalActions();
+			this.registerInternalServices();
 
 		// Graceful exit
 		this._closeFn = () => {
@@ -482,7 +482,7 @@ class ServiceBroker {
 			})
 			.then(() => {
 				_.remove(this.services, svc => svc == service);
-				this.serviceRegistry.unregisterService(LOCAL_NODE_ID, service.name);
+				this.serviceRegistry.unregisterService(this.nodeID, service.name);
 
 				this.logger.info(`Service '${service.name}' is destroyed!`);
 				this.servicesChanged();
@@ -499,7 +499,7 @@ class ServiceBroker {
 	registerLocalService(service) {
 		this.services.push(service);
 
-		this.serviceRegistry.registerService(LOCAL_NODE_ID, service);
+		this.serviceRegistry.registerService(this.nodeID, service);
 
 		//this.emitLocal(`register.service.${service.name}`, service);
 		this.logger.info(`'${service.name}' service is registered!`);
@@ -534,7 +534,7 @@ class ServiceBroker {
 	 */
 	registerAction(nodeID, action) {
 		// Wrap middlewares on local actions
-		if (nodeID == LOCAL_NODE_ID)
+		if (nodeID == this.nodeID)
 			this.wrapAction(action);
 
 		this.serviceRegistry.registerAction(nodeID, action);
@@ -586,87 +586,12 @@ class ServiceBroker {
 	}
 
 	/**
-	 * Register internal actions
+	 * Register internal services
 	 *
 	 * @memberOf ServiceBroker
 	 */
-	registerInternalActions() {
+	registerInternalServices() {
 		this.createService(require("./internals")(this));
-		/*this.serviceRegistry.registerService(LOCAL_NODE_ID, {
-			name: "$node",
-			settings: {}
-		});
-
-		const addAction = (name, handler) => {
-			this.registerAction(LOCAL_NODE_ID, {
-				name,
-				cache: false,
-				handler: Promise.method(handler),
-				service: {
-					name: "$node"
-				}
-			});
-		};
-
-		addAction("$node.list", () => {
-			let res = [];
-			const localNode = this.transit.getNodeInfo();
-			localNode.id = LOCAL_NODE_ID;
-			localNode.available = true;
-			res.push(localNode);
-
-			this.transit.nodes.forEach(node => {
-				//res.push(pick(node, ["nodeID", "available"]));
-				res.push(node);
-			});
-
-			return res;
-		});
-
-		addAction("$node.services", ctx => {
-			let res = [];
-
-			const services = this.serviceRegistry.getServiceList(ctx.params);
-
-			services.forEach(svc => {
-				let item = res.find(o => o.name == svc.name && o.version == svc.version);
-				if (item) {
-					item.nodes.push(svc.nodeID);
-					// Merge services
-					_.forIn(svc.actions, (action, name) => {
-						if (action.protected === true) return;
-
-						if (!item.actions[name])
-							item.actions[name] = _.omit(action, ["handler", "service"]);
-					});
-
-				} else {
-					item = _.pick(svc, ["name", "version", "settings"]);
-					item.nodes = [svc.nodeID];
-					item.actions = {};
-					_.forIn(svc.actions, (action, name) => {
-						if (action.protected === true) return;
-
-						item.actions[name] = _.omit(action, ["handler", "service"]);
-					});
-					res.push(item);
-				}
-			});
-
-			return res;
-		});
-
-		addAction("$node.actions", ctx => {
-			return this.serviceRegistry.getActionList(ctx.params);
-		});
-
-		addAction("$node.health", () => this.getNodeHealthInfo());
-
-		if (this.statistics) {
-			addAction("$node.stats", () => {
-				return this.statistics.snapshot();
-			});
-		}*/
 	}
 
 	/**
@@ -984,11 +909,11 @@ class ServiceBroker {
 			err = new E.MoleculerError(err, 500);
 		}
 		if (err instanceof Promise.TimeoutError)
-			err = new E.RequestTimeoutError(actionName, nodeID || this.nodeID);
+			err = new E.RequestTimeoutError(actionName, nodeID);
 
 		err.ctx = ctx;
 
-		if (nodeID) {
+		if (nodeID != this.nodeID) {
 			// Remove pending request
 			this.transit.removePendingRequest(ctx.id);
 		}

--- a/src/service-broker.js
+++ b/src/service-broker.js
@@ -30,8 +30,6 @@ const RoundRobinStrategy = require("./strategies/round-robin");
 const { CIRCUIT_HALF_OPEN } 	= require("./constants");
 
 
-const LOCAL_NODE_ID = null; // `null` means local nodeID
-
 const defaultConfig = {
 	namespace: "",
 	nodeID: null,
@@ -1075,16 +1073,6 @@ ServiceBroker.MOLECULER_VERSION = require("../package.json").version;
  * Version of Moleculer
  */
 ServiceBroker.prototype.MOLECULER_VERSION = ServiceBroker.MOLECULER_VERSION;
-
-/**
- * Local NodeID
- */
-ServiceBroker.LOCAL_NODE_ID = LOCAL_NODE_ID;
-
-/**
- * Local NodeID
- */
-ServiceBroker.prototype.LOCAL_NODE_ID = LOCAL_NODE_ID;
 
 /**
  * Default configuration

--- a/src/service-registry.js
+++ b/src/service-registry.js
@@ -7,6 +7,7 @@
 "use strict";
 
 const _ = require("lodash");
+const { MoleculerError } = require("./errors");
 
 const RoundRobinStrategy = require("./strategies/round-robin");
 
@@ -294,6 +295,7 @@ class ServiceRegistry {
 				const ep = entry.list[0];
 				item.action = _.omit(ep.action, ["handler", "service"]);
 			}
+			if (item.action.protected === true) return;
 
 			if (withEndpoints) {
 				if (item.count > 0) {
@@ -427,7 +429,7 @@ class EndpointList {
 	get() {
 		const ret = this.getStrategy().select(this.list);
 		if (!ret) {
-			throw new Error(`Strategy ${typeof(this.getStrategy())} returned an invalid endpoint.`);
+			throw new MoleculerError(`Strategy ${typeof(this.getStrategy())} returned an invalid endpoint.`);
 		}
 		return ret;
 	}

--- a/src/service.js
+++ b/src/service.js
@@ -17,17 +17,17 @@ const { ServiceSchemaError } = require("./errors");
 
 /**
  * Main Service class
- * 
+ *
  * @class Service
  */
 class Service {
 
 	/**
 	 * Creates an instance of Service by schema.
-	 * 
+	 *
 	 * @param {ServiceBroker} 	broker	broker of service
 	 * @param {Object} 			schema	schema of service
-	 * 
+	 *
 	 * @memberOf Service
 	 */
 	constructor(broker, schema) {
@@ -71,7 +71,7 @@ class Service {
 				let innerAction = this._createAction(action, name);
 
 				// Register to broker
-				broker.registerAction(null, innerAction);
+				broker.registerAction(this.broker.nodeID, innerAction);
 
 				// Expose to call `service.actions.find({ ...params })`
 				this.actions[name] = (params, opts) => {
@@ -164,11 +164,11 @@ class Service {
 
 	/**
 	 * Create an external action handler for broker (internal command!)
-	 * 
+	 *
 	 * @param {any} actionDef
 	 * @param {any} name
 	 * @returns
-	 * 
+	 *
 	 * @memberOf Service
 	 */
 	_createAction(actionDef, name) {
@@ -212,11 +212,11 @@ class Service {
 
 	/**
 	 * Apply `mixins` list in schema. Merge the schema with mixins schemas. Returns with the mixed schema
-	 * 
+	 *
 	 * @static
-	 * @param {Schema} schema 
+	 * @param {Schema} schema
 	 * @returns {Schema}
-	 * 
+	 *
 	 * @memberof Service
 	 */
 	static applyMixins(schema) {

--- a/src/transit.js
+++ b/src/transit.js
@@ -14,18 +14,18 @@ const { hash } 					= require("node-object-hash")({ sort: false, coerce: false})
 
 /**
  * Transit class
- * 
+ *
  * @class Transit
  */
 class Transit {
 
 	/**
 	 * Create an instance of Transit.
-	 * 
+	 *
 	 * @param {ServiceBroker} Broker instance
 	 * @param {Transporter} Transporter instance
 	 * @param {Object?} opts
-	 * 
+	 *
 	 * @memberOf Transit
 	 */
 	constructor(broker, transporter, opts) {
@@ -60,10 +60,10 @@ class Transit {
 
 	/**
 	 * It will be called after transporter connected or reconnected.
-	 * 
-	 * @param {any} wasReconnect 
+	 *
+	 * @param {any} wasReconnect
 	 * @returns {Promise}
-	 * 
+	 *
 	 * @memberof Transit
 	 */
 	afterConnect(wasReconnect) {
@@ -89,7 +89,7 @@ class Transit {
 
 	/**
 	 * Connect with transporter. If failed, try again after 5 sec.
-	 * 
+	 *
 	 * @memberOf Transit
 	 */
 	connect() {
@@ -133,7 +133,7 @@ class Transit {
 
 	/**
 	 * Disconnect with transporter
-	 * 
+	 *
 	 * @memberOf Transit
 	 */
 	disconnect() {
@@ -158,9 +158,9 @@ class Transit {
 
 	/**
 	 * Send DISCONNECT to remote nodes
-	 * 
+	 *
 	 * @returns {Promise}
-	 * 
+	 *
 	 * @memberOf Transit
 	 */
 	sendDisconnectPacket() {
@@ -171,7 +171,7 @@ class Transit {
 
 	/**
 	 * Subscribe to topics for transportation
-	 * 
+	 *
 	 * @memberOf Transit
 	 */
 	makeSubscriptions() {
@@ -206,10 +206,10 @@ class Transit {
 
 	/**
 	 * Emit an event to remote nodes
-	 * 
+	 *
 	 * @param {any} eventName
 	 * @param {any} data
-	 * 
+	 *
 	 * @memberOf Transit
 	 */
 	emit(eventName, data) {
@@ -218,11 +218,11 @@ class Transit {
 
 	/**
 	 * Message handler for incoming packets
-	 * 
-	 * @param {Array} topic 
-	 * @param {String} msg 
-	 * @returns 
-	 * 
+	 *
+	 * @param {Array} topic
+	 * @param {String} msg
+	 * @returns
+	 *
 	 * @memberOf Transit
 	 */
 	messageHandler(cmd, msg) {
@@ -288,17 +288,17 @@ class Transit {
 
 	/**
 	 * Handle incoming request
-	 * 
-	 * @param {Object} packet 
+	 *
+	 * @param {Object} packet
 	 * @returns {Promise}
-	 * 
+	 *
 	 * @memberOf Transit
 	 */
 	_requestHandler(payload) {
 		this.logger.debug(`Request '${payload.action}' received from '${payload.sender}' node.`);
 
 		// Recreate caller context
-		const ctx = new Context(this.broker);
+		const ctx = new this.broker.ContextFactory(this.broker);
 		ctx.action = {
 			name: payload.action
 		};
@@ -317,10 +317,10 @@ class Transit {
 
 	/**
 	 * Process incoming response of request
-	 * 
-	 * @param {Object} packet 
+	 *
+	 * @param {Object} packet
 	 * @returns {Promise}
-	 * 
+	 *
 	 * @memberOf Transit
 	 */
 	_responseHandler(packet) {
@@ -358,10 +358,10 @@ class Transit {
 	/**
 	 * Send a request to a remote service. It returns a Promise
 	 * what will be resolved when the response received.
-	 * 
+	 *
 	 * @param {<Context>} ctx			Context of request
 	 * @returns	{Promise}
-	 * 
+	 *
 	 * @memberOf Transit
 	 */
 	request(ctx) {
@@ -371,11 +371,11 @@ class Transit {
 
 	/**
 	 * Do a remote request
-	 * 
+	 *
 	 * @param {<Context>} ctx 		Context of request
 	 * @param {Function} resolve 	Resolve of Promise
 	 * @param {Function} reject 	Reject of Promise
-	 * 
+	 *
 	 * @memberOf Transit
 	 */
 	_doRequest(ctx, resolve, reject) {
@@ -403,9 +403,9 @@ class Transit {
 
 	/**
 	 * Remove a pending request
-	 * 
-	 * @param {any} id 
-	 * 
+	 *
+	 * @param {any} id
+	 *
 	 * @memberOf Transit
 	 */
 	removePendingRequest(id) {
@@ -414,12 +414,12 @@ class Transit {
 
 	/**
 	 * Send back the response of request
-	 * 
-	 * @param {String} nodeID 
+	 *
+	 * @param {String} nodeID
 	 * @param {String} id
-	 * @param {any} data 
-	 * @param {Error} err 
-	 * 
+	 * @param {any} data
+	 * @param {Error} err
+	 *
 	 * @memberOf Transit
 	 */
 	sendResponse(nodeID, id, data, err) {
@@ -431,9 +431,9 @@ class Transit {
 
 	/**
 	 * Get Node information to DISCOVER & INFO packages
-	 * 
+	 *
 	 * @returns {Object}
-	 * 
+	 *
 	 * @memberof Transit
 	 */
 	getNodeInfo() {
@@ -455,7 +455,7 @@ class Transit {
 
 	/**
 	 * Discover other nodes. It will be called after success connect.
-	 * 
+	 *
 	 * @memberOf Transit
 	 */
 	discoverNodes() {
@@ -464,7 +464,7 @@ class Transit {
 
 	/**
 	 * Send node info package to other nodes. It will be called with timer
-	 * 
+	 *
 	 * @memberOf Transit
 	 */
 	sendNodeInfo(nodeID) {
@@ -474,7 +474,7 @@ class Transit {
 
 	/**
 	 * Send a node heart-beat. It will be called with timer
-	 * 
+	 *
 	 * @memberOf Transit
 	 */
 	sendHeartbeat() {
@@ -484,10 +484,10 @@ class Transit {
 
 	/**
 	 * Subscribe via transporter
-	 * 
-	 * @param {String} topic 
+	 *
+	 * @param {String} topic
 	 * @param {String=} nodeID
-	 * 
+	 *
 	 * @memberOf Transit
 	 */
 	subscribe(topic, nodeID) {
@@ -496,9 +496,9 @@ class Transit {
 
 	/**
 	 * Publish via transporter
-	 * 
+	 *
 	 * @param {Packet} Packet
-	 * 
+	 *
 	 * @memberOf Transit
 	 */
 	publish(packet) {
@@ -515,10 +515,10 @@ class Transit {
 
 	/**
 	 * Serialize the object
-	 * 
-	 * @param {Object} obj 
+	 *
+	 * @param {Object} obj
 	 * @returns {Buffer}
-	 * 
+	 *
 	 * @memberOf Transit
 	 */
 	serialize(obj, type) {
@@ -527,10 +527,10 @@ class Transit {
 
 	/**
 	 * Deserialize the incoming Buffer to object
-	 * 
+	 *
 	 * @param {Buffer} buf
 	 * @returns {any}
-	 * 
+	 *
 	 * @memberOf Transit
 	 */
 	deserialize(buf, type) {
@@ -541,10 +541,10 @@ class Transit {
 
 	/**
 	 * Process remote node info (list of actions)
-	 * 
+	 *
 	 * @param {String} nodeID
 	 * @param {Object} payload
-	 * 
+	 *
 	 * @memberOf Transit
 	 */
 	processNodeInfo(nodeID, payload) {
@@ -602,10 +602,10 @@ class Transit {
 
 	/**
 	 * Check the given nodeID is available
-	 * 
+	 *
 	 * @param {any} nodeID	Node ID
 	 * @returns {boolean}
-	 * 
+	 *
 	 * @memberOf Transit
 	 */
 	isNodeAvailable(nodeID) {
@@ -618,10 +618,10 @@ class Transit {
 
 	/**
 	 * Save a heart-beat time from a remote node
-	 * 
+	 *
 	 * @param {any} nodeID
 	 * @param {Object} payload
-	 * 
+	 *
 	 * @memberOf Transit
 	 */
 	nodeHeartbeat(nodeID, payload) {
@@ -634,12 +634,12 @@ class Transit {
 	}
 
 	/**
-	 * Node disconnected event handler. 
+	 * Node disconnected event handler.
 	 * Remove node and remove remote actions of node
-	 * 
+	 *
 	 * @param {any} nodeID
 	 * @param {Boolean=} isUnexpected
-	 * 
+	 *
 	 * @memberOf Transit
 	 */
 	nodeDisconnected(nodeID, isUnexpected) {
@@ -650,7 +650,7 @@ class Transit {
 				this.broker.unregisterServicesByNode(nodeID);
 
 				this.broker.emitLocal("node.disconnected", { node, unexpected: !!isUnexpected });
-				//this.nodes.delete(nodeID);			
+				//this.nodes.delete(nodeID);
 				this.logger.warn(`Node '${nodeID}' disconnected!`);
 			}
 		}
@@ -658,7 +658,7 @@ class Transit {
 
 	/**
 	 * Check all registered remote nodes is live.
-	 * 
+	 *
 	 * @memberOf Transit
 	 */
 	checkRemoteNodes() {

--- a/test/integration/broker.spec.js
+++ b/test/integration/broker.spec.js
@@ -43,7 +43,7 @@ describe("Test broker.registerInternalServices", () => {
 	let broker = new ServiceBroker({
 		nodeID: "server-1",
 		statistics: true,
-		internalActions: true,
+		internalServices: true,
 		transporter: new FakeTransporter()
 	});
 

--- a/test/integration/broker.spec.js
+++ b/test/integration/broker.spec.js
@@ -39,7 +39,7 @@ describe("Test load services", () => {
 });
 
 
-describe("Test broker.registerInternalActions", () => {
+describe("Test broker.registerInternalServices", () => {
 	let broker = new ServiceBroker({
 		nodeID: "server-1",
 		statistics: true,
@@ -505,7 +505,7 @@ describe("Test local call", () => {
 			expect(ctx).toBeDefined();
 			expect(ctx.broker).toBe(broker);
 			expect(ctx.action.name).toBe("posts.find");
-			expect(ctx.nodeID).toBeNull();
+			expect(ctx.nodeID).toBe(broker.nodeID);
 			expect(ctx.params).toBeDefined();
 			expect(actionHandler).toHaveBeenCalledTimes(1);
 			expect(actionHandler).toHaveBeenCalledWith(ctx);

--- a/test/integration/broker.spec.js
+++ b/test/integration/broker.spec.js
@@ -41,9 +41,9 @@ describe("Test load services", () => {
 
 describe("Test broker.registerInternalActions", () => {
 	let broker = new ServiceBroker({
+		nodeID: "server-1",
 		statistics: true,
 		internalActions: true,
-		nodeID: "server-1",
 		transporter: new FakeTransporter()
 	});
 
@@ -64,7 +64,8 @@ describe("Test broker.registerInternalActions", () => {
 				{
 					"action": {
 						"cache": false,
-						"name": "$node.list"
+						"name": "$node.list",
+						"version": undefined
 					},
 					"available": true,
 					"count": 1,
@@ -74,7 +75,22 @@ describe("Test broker.registerInternalActions", () => {
 				{
 					"action": {
 						"cache": false,
-						"name": "$node.services"
+						"name": "$node.services",
+						"params": {
+							"onlyLocal": {
+								"optional": true,
+								"type": "boolean"
+							},
+							"skipInternal": {
+								"optional": true,
+								"type": "boolean"
+							},
+							"withActions": {
+								"optional": true,
+								"type": "boolean"
+							}
+						},
+						"version": undefined
 					},
 					"available": true,
 					"count": 1,
@@ -84,7 +100,22 @@ describe("Test broker.registerInternalActions", () => {
 				{
 					"action": {
 						"cache": false,
-						"name": "$node.actions"
+						"name": "$node.actions",
+						"params": {
+							"onlyLocal": {
+								"optional": true,
+								"type": "boolean"
+							},
+							"skipInternal": {
+								"optional": true,
+								"type": "boolean"
+							},
+							"withEndpoints": {
+								"optional": true,
+								"type": "boolean"
+							}
+						},
+						"version": undefined
 					},
 					"available": true,
 					"count": 1,
@@ -94,7 +125,8 @@ describe("Test broker.registerInternalActions", () => {
 				{
 					"action": {
 						"cache": false,
-						"name": "$node.health"
+						"name": "$node.health",
+						"version": undefined
 					},
 					"available": true,
 					"count": 1,
@@ -104,7 +136,8 @@ describe("Test broker.registerInternalActions", () => {
 				{
 					"action": {
 						"cache": false,
-						"name": "$node.stats"
+						"name": "$node.stats",
+						"version": undefined
 					},
 					"available": true,
 					"count": 1,
@@ -232,30 +265,66 @@ describe("Test broker.registerInternalActions", () => {
 				"actions": {
 					"$node.actions": {
 						"cache": false,
-						"name": "$node.actions"
+						"name": "$node.actions",
+						"params": {
+							"onlyLocal": {
+								"optional": true,
+								"type": "boolean"
+							},
+							"skipInternal": {
+								"optional": true,
+								"type": "boolean"
+							},
+							"withEndpoints": {
+								"optional": true,
+								"type": "boolean"
+							}
+						},
+						"version": undefined
 					},
 					"$node.health": {
 						"cache": false,
-						"name": "$node.health"
+						"name": "$node.health",
+						"version": undefined
 					},
 					"$node.list": {
 						"cache": false,
-						"name": "$node.list"
+						"name": "$node.list",
+						"version": undefined
 					},
 					"$node.services": {
 						"cache": false,
-						"name": "$node.services"
+						"name": "$node.services",
+						"params": {
+							"onlyLocal": {
+								"optional": true,
+								"type": "boolean"
+							},
+							"skipInternal": {
+								"optional": true,
+								"type": "boolean"
+							},
+							"withActions": {
+								"optional": true,
+								"type": "boolean"
+							}
+						},
+						"version": undefined
 					},
 					"$node.stats": {
 						"cache": false,
-						"name": "$node.stats"
+						"name": "$node.stats",
+						"version": undefined
 					}
 				},
 				"name": "$node",
-				"nodes": [null],
+				"nodes": [
+					"server-1"
+				],
 				"settings": {},
 				"version": undefined
-			}, {
+			},
+			{
 				"actions": {
 					"math.add": {
 						"cache": false,
@@ -282,7 +351,7 @@ describe("Test broker.registerInternalActions", () => {
 					},
 					"math.pow": {
 						"cache": true,
-						"name": "math.pow",
+						"name": "math.pow"
 					},
 					"math.sub": {
 						"cache": false,
@@ -291,10 +360,14 @@ describe("Test broker.registerInternalActions", () => {
 					}
 				},
 				"name": "math",
-				"nodes": [null, "node-3"],
+				"nodes": [
+					"server-1",
+					"node-3"
+				],
 				"settings": {},
 				"version": undefined
-			}, {
+			},
+			{
 				"actions": {
 					"posts.author": {
 						"cache": false,
@@ -313,14 +386,18 @@ describe("Test broker.registerInternalActions", () => {
 					},
 					"posts.get": {
 						"cache": {
-							"keys": ["id"]
+							"keys": [
+								"id"
+							]
 						},
 						"name": "posts.get",
 						"version": undefined
 					}
 				},
 				"name": "posts",
-				"nodes": [null],
+				"nodes": [
+					"server-1"
+				],
 				"settings": {},
 				"version": undefined
 			}]);
@@ -356,7 +433,8 @@ describe("Test broker.registerInternalActions", () => {
 		return broker.call("$node.list").then(res => {
 			expect(res).toBeInstanceOf(Array);
 			expect(res.length).toBe(2);
-			expect(res[0].id).toBeNull();
+			expect(res[0].id).toBe("server-1");
+			expect(res[0].local).toBe(true);
 			expect(res[0].services.length).toBe(3);
 			expect(res[1]).toEqual({"services": [], "available": true, "id": "server-2", "lastHeartbeatTime": jasmine.any(Number), "nodeID": "server-2"});
 		});

--- a/test/unit/context.spec.js
+++ b/test/unit/context.spec.js
@@ -47,6 +47,7 @@ describe("Test Context", () => {
 
 		expect(ctx.broker).toBe(broker);
 		expect(ctx.action).toBe(action);
+		expect(ctx.nodeID).toBe(broker.nodeID);
 	});
 });
 

--- a/test/unit/service-broker.spec.js
+++ b/test/unit/service-broker.spec.js
@@ -660,7 +660,7 @@ describe("Test broker.getLogger", () => {
 
 	it("should create default console logger with logFormatter", () => {
 		let logFormatter = jest.fn();
-		let broker = new ServiceBroker({ logger: true, logFormatter });
+		let broker = new ServiceBroker({ internalActions: false, logger: true, logFormatter });
 
 		console.info.mockClear();
 		broker.logger.info("Teszt", { a: 5 });
@@ -674,7 +674,7 @@ describe("Test broker.getLogger", () => {
 		let broker;
 
 		it("should call logger function with broker bindings", () => {
-			broker = new ServiceBroker({ logger, namespace: "testing", nodeID: "test-pc" });
+			broker = new ServiceBroker({ internalActions: false, logger, namespace: "testing", nodeID: "test-pc" });
 
 			expect(logger).toHaveBeenCalledTimes(1);
 			expect(logger).toHaveBeenCalledWith({"mod": "broker", "nodeID": "test-pc", "ns": "testing"});
@@ -702,7 +702,7 @@ describe("Test broker.getLogger", () => {
 		let logger = {
 			info: jest.fn()
 		};
-		let broker = new ServiceBroker({ logger });
+		let broker = new ServiceBroker({ internalActions: false, logger });
 
 		expect(logger.fatal).toBeDefined();
 		expect(logger.error).toBeDefined();
@@ -873,7 +873,7 @@ describe("Test broker.createService", () => {
 describe("Test broker.destroyService", () => {
 
 	let stopped = jest.fn();
-	let broker = new ServiceBroker();
+	let broker = new ServiceBroker({ internalActions: false });
 	let service = broker.createService({
 		name: "greeter",
 		actions: {
@@ -944,7 +944,7 @@ describe("Test broker.servicesChanged", () => {
 
 describe("Test broker.registerLocalService", () => {
 
-	let broker = new ServiceBroker();
+	let broker = new ServiceBroker({ internalActions: false });
 	broker.emitLocal = jest.fn();
 	broker.serviceRegistry.registerService = jest.fn();
 
@@ -964,7 +964,7 @@ describe("Test broker.registerLocalService", () => {
 
 describe("Test broker.registerRemoteService", () => {
 
-	let broker = new ServiceBroker();
+	let broker = new ServiceBroker({ internalActions: false });
 	broker.serviceRegistry.registerService = jest.fn();
 	broker.registerAction = jest.fn();
 
@@ -1252,16 +1252,17 @@ describe("Test broker.registerInternalActions", () => {
 			statistics: false,
 			internalActions: false
 		});
-		const service = {"name": "$node"};
 
-		broker.registerAction = jest.fn();
+		broker.createService = jest.fn();
 		broker.registerInternalActions();
 
-		expect(broker.registerAction).toHaveBeenCalledTimes(4);
-		expect(broker.registerAction).toHaveBeenCalledWith(null, { name: "$node.list", cache: false, handler: jasmine.any(Function), service });
-		expect(broker.registerAction).toHaveBeenCalledWith(null, { name: "$node.services", cache: false, handler: jasmine.any(Function), service });
-		expect(broker.registerAction).toHaveBeenCalledWith(null, { name: "$node.actions", cache: false, handler: jasmine.any(Function), service });
-		expect(broker.registerAction).toHaveBeenCalledWith(null, { name: "$node.health", cache: false, handler: jasmine.any(Function), service });
+		expect(broker.createService).toHaveBeenCalledTimes(1);
+		expect(broker.createService).toHaveBeenCalledWith({ name: "$node", actions: {
+			list: jasmine.any(Object),
+			services: jasmine.any(Object),
+			actions: jasmine.any(Object),
+			health: jasmine.any(Object),
+		} });
 	});
 
 	it("should register internal action with statistics", () => {
@@ -1269,13 +1270,18 @@ describe("Test broker.registerInternalActions", () => {
 			statistics: true,
 			internalActions: false
 		});
-		const service = {"name": "$node"};
 
-		broker.registerAction = jest.fn();
+		broker.createService = jest.fn();
 		broker.registerInternalActions();
 
-		expect(broker.registerAction).toHaveBeenCalledTimes(5);
-		expect(broker.registerAction).toHaveBeenCalledWith(null, { name: "$node.stats", cache: false, handler: jasmine.any(Function), service });
+		expect(broker.createService).toHaveBeenCalledTimes(1);
+		expect(broker.createService).toHaveBeenCalledWith({ name: "$node", actions: {
+			list: jasmine.any(Object),
+			services: jasmine.any(Object),
+			actions: jasmine.any(Object),
+			health: jasmine.any(Object),
+			stats: jasmine.any(Object),
+		} });
 	});
 });
 

--- a/test/unit/service-broker.spec.js
+++ b/test/unit/service-broker.spec.js
@@ -68,7 +68,7 @@ describe("Test ServiceBroker constructor", () => {
 			metrics: false,
 			metricsRate: 1,
 			statistics: false,
-			internalActions: true
+			internalServices: true
 		});
 
 		expect(broker.Promise).toBe(Promise);
@@ -128,7 +128,7 @@ describe("Test ServiceBroker constructor", () => {
 				failureOnReject: false
 			},
 			validation: false,
-			internalActions: false });
+			internalServices: false });
 
 		expect(broker).toBeDefined();
 		expect(broker.options).toEqual({
@@ -161,7 +161,7 @@ describe("Test ServiceBroker constructor", () => {
 			requestTimeout: 5000,
 			maxCallLevel: 10,
 			validation: false,
-			internalActions: false });
+			internalServices: false });
 		expect(broker.services).toBeInstanceOf(Array);
 		expect(broker.serviceRegistry).toBeInstanceOf(ServiceRegistry);
 		expect(broker.transit).toBeUndefined();
@@ -660,7 +660,7 @@ describe("Test broker.getLogger", () => {
 
 	it("should create default console logger with logFormatter", () => {
 		let logFormatter = jest.fn();
-		let broker = new ServiceBroker({ internalActions: false, logger: true, logFormatter });
+		let broker = new ServiceBroker({ internalServices: false, logger: true, logFormatter });
 
 		console.info.mockClear();
 		broker.logger.info("Teszt", { a: 5 });
@@ -674,7 +674,7 @@ describe("Test broker.getLogger", () => {
 		let broker;
 
 		it("should call logger function with broker bindings", () => {
-			broker = new ServiceBroker({ internalActions: false, logger, namespace: "testing", nodeID: "test-pc" });
+			broker = new ServiceBroker({ internalServices: false, logger, namespace: "testing", nodeID: "test-pc" });
 
 			expect(logger).toHaveBeenCalledTimes(1);
 			expect(logger).toHaveBeenCalledWith({"mod": "broker", "nodeID": "test-pc", "ns": "testing"});
@@ -702,7 +702,7 @@ describe("Test broker.getLogger", () => {
 		let logger = {
 			info: jest.fn()
 		};
-		let broker = new ServiceBroker({ internalActions: false, logger });
+		let broker = new ServiceBroker({ internalServices: false, logger });
 
 		expect(logger.fatal).toBeDefined();
 		expect(logger.error).toBeDefined();
@@ -873,7 +873,7 @@ describe("Test broker.createService", () => {
 describe("Test broker.destroyService", () => {
 
 	let stopped = jest.fn();
-	let broker = new ServiceBroker({ internalActions: false });
+	let broker = new ServiceBroker({ internalServices: false });
 	let service = broker.createService({
 		name: "greeter",
 		actions: {
@@ -944,7 +944,7 @@ describe("Test broker.servicesChanged", () => {
 
 describe("Test broker.registerLocalService", () => {
 
-	let broker = new ServiceBroker({ internalActions: false });
+	let broker = new ServiceBroker({ internalServices: false });
 	broker.emitLocal = jest.fn();
 	broker.serviceRegistry.registerService = jest.fn();
 
@@ -964,7 +964,7 @@ describe("Test broker.registerLocalService", () => {
 
 describe("Test broker.registerRemoteService", () => {
 
-	let broker = new ServiceBroker({ internalActions: false });
+	let broker = new ServiceBroker({ internalServices: false });
 	broker.serviceRegistry.registerService = jest.fn();
 	broker.registerAction = jest.fn();
 
@@ -1250,7 +1250,7 @@ describe("Test broker.registerInternalServices", () => {
 	it("should register internal action without statistics", () => {
 		let broker = new ServiceBroker({
 			statistics: false,
-			internalActions: false
+			internalServices: false
 		});
 
 		broker.createService = jest.fn();
@@ -1268,7 +1268,7 @@ describe("Test broker.registerInternalServices", () => {
 	it("should register internal action with statistics", () => {
 		let broker = new ServiceBroker({
 			statistics: true,
-			internalActions: false
+			internalServices: false
 		});
 
 		broker.createService = jest.fn();
@@ -1434,7 +1434,7 @@ describe("Test broker.call method", () => {
 
 	describe("Test local call", () => {
 
-		let broker = new ServiceBroker({ internalActions: false, metrics: true });
+		let broker = new ServiceBroker({ internalServices: false, metrics: true });
 
 		let actionHandler = jest.fn(ctx => ctx);
 		broker.createService({
@@ -1654,7 +1654,7 @@ describe("Test broker.call method", () => {
 
 		let broker = new ServiceBroker({
 			transporter: new FakeTransporter(),
-			internalActions: false,
+			internalServices: false,
 			metrics: true
 		});
 		broker.registerAction("server-2", {	name: "user.create", service: { name: "user" } });
@@ -1706,7 +1706,7 @@ describe("Test broker.call method", () => {
 		let broker = new ServiceBroker({
 			nodeID: "server-0",
 			transporter: new FakeTransporter(),
-			internalActions: false,
+			internalServices: false,
 			metrics: true
 		});
 		const service = { name: "user" };
@@ -1769,7 +1769,7 @@ describe("Test broker.call method", () => {
 
 describe("Test broker.mcall", () => {
 
-	let broker = new ServiceBroker({ internalActions: false });
+	let broker = new ServiceBroker({ internalServices: false });
 	broker.call = jest.fn(action => Promise.resolve(action));
 
 	it("should call both action & return an array", () => {

--- a/test/unit/service-registry.spec.js
+++ b/test/unit/service-registry.spec.js
@@ -674,7 +674,8 @@ describe("Test registry.getActionList", () => {
 			{
 				"action": {
 					"cache": false,
-					"name": "$node.list"
+					"name": "$node.list",
+					"version": undefined
 				},
 				"available": true,
 				"count": 1,
@@ -684,7 +685,22 @@ describe("Test registry.getActionList", () => {
 			{
 				"action": {
 					"cache": false,
-					"name": "$node.services"
+					"name": "$node.services",
+					"params": {
+						"onlyLocal": {
+							"optional": true,
+							"type": "boolean"
+						},
+						"skipInternal": {
+							"optional": true,
+							"type": "boolean"
+						},
+						"withActions": {
+							"optional": true,
+							"type": "boolean"
+						}
+					},
+					"version": undefined
 				},
 				"available": true,
 				"count": 1,
@@ -694,7 +710,22 @@ describe("Test registry.getActionList", () => {
 			{
 				"action": {
 					"cache": false,
-					"name": "$node.actions"
+					"name": "$node.actions",
+					"params": {
+						"onlyLocal": {
+							"optional": true,
+							"type": "boolean"
+						},
+						"skipInternal": {
+							"optional": true,
+							"type": "boolean"
+						},
+						"withEndpoints": {
+							"optional": true,
+							"type": "boolean"
+						}
+					},
+					"version": undefined
 				},
 				"available": true,
 				"count": 1,
@@ -704,7 +735,8 @@ describe("Test registry.getActionList", () => {
 			{
 				"action": {
 					"cache": false,
-					"name": "$node.health"
+					"name": "$node.health",
+					"version": undefined
 				},
 				"available": true,
 				"count": 1,

--- a/test/unit/service-registry.spec.js
+++ b/test/unit/service-registry.spec.js
@@ -89,7 +89,7 @@ describe("Test registry.init", () => {
 });
 
 describe("Test registry.registerService", () => {
-	const broker = new ServiceBroker({ internalActions: false });
+	const broker = new ServiceBroker({ internalServices: false });
 	const registry = broker.serviceRegistry;
 
 	let service = {
@@ -125,7 +125,7 @@ describe("Test registry.registerService", () => {
 });
 
 describe("Test registry.unregisterService", () => {
-	const broker = new ServiceBroker({ internalActions: false });
+	const broker = new ServiceBroker({ internalServices: false });
 	const registry = broker.serviceRegistry;
 
 	let service = {
@@ -181,7 +181,7 @@ describe("Test registry.unregisterService", () => {
 });
 
 describe("Test registry.unregisterServicesByNode", () => {
-	const broker = new ServiceBroker({ internalActions: false });
+	const broker = new ServiceBroker({ internalServices: false });
 	const registry = broker.serviceRegistry;
 
 	let service = {
@@ -226,7 +226,7 @@ describe("Test registry.unregisterServicesByNode", () => {
 });
 
 describe("Test registry.findService", () => {
-	const broker = new ServiceBroker({ internalActions: false });
+	const broker = new ServiceBroker({ internalServices: false });
 	const registry = broker.serviceRegistry;
 
 	let serviceV1 = {
@@ -274,7 +274,7 @@ describe("Test registry.findService", () => {
 });
 
 describe("Test registry.findServiceByNode", () => {
-	const broker = new ServiceBroker({ internalActions: false });
+	const broker = new ServiceBroker({ internalServices: false });
 	const registry = broker.serviceRegistry;
 
 	let service = {
@@ -297,7 +297,7 @@ describe("Test registry.findServiceByNode", () => {
 });
 
 describe("Test registry.registerAction", () => {
-	const broker = new ServiceBroker({ internalActions: false });
+	const broker = new ServiceBroker({ internalServices: false });
 	const registry = broker.serviceRegistry;
 
 	let service = {
@@ -346,7 +346,7 @@ describe("Test registry.registerAction", () => {
 });
 
 describe("Test registry.unregisterAction", () => {
-	const broker = new ServiceBroker({ internalActions: false });
+	const broker = new ServiceBroker({ internalServices: false });
 	const registry = broker.serviceRegistry;
 
 	let service = {
@@ -379,7 +379,7 @@ describe("Test registry.unregisterAction", () => {
 });
 
 describe("Test registry.findAction", () => {
-	const broker = new ServiceBroker({ internalActions: false });
+	const broker = new ServiceBroker({ internalServices: false });
 	const registry = broker.serviceRegistry;
 
 	let service = {
@@ -408,7 +408,7 @@ describe("Test registry.findAction", () => {
 });
 
 describe("Test registry.findAction with internal actions", () => {
-	const broker = new ServiceBroker({ internalActions: true, registry: { preferLocal: false } });
+	const broker = new ServiceBroker({ internalServices: true, registry: { preferLocal: false } });
 	const registry = broker.serviceRegistry;
 
 	let service = {
@@ -440,7 +440,7 @@ describe("Test registry.findAction with internal actions", () => {
 });
 
 describe("Test registry.getEndpointByNodeID", () => {
-	const broker = new ServiceBroker({ internalActions: true, registry: { preferLocal: false } });
+	const broker = new ServiceBroker({ internalServices: true, registry: { preferLocal: false } });
 	const registry = broker.serviceRegistry;
 
 	let service = {
@@ -492,7 +492,7 @@ describe("Test registry.getEndpointByNodeID", () => {
 });
 
 describe("Test registry.hasAction", () => {
-	const broker = new ServiceBroker({ internalActions: false });
+	const broker = new ServiceBroker({ internalServices: false });
 	const registry = broker.serviceRegistry;
 
 	let service = {
@@ -521,7 +521,7 @@ describe("Test registry.hasAction", () => {
 });
 
 describe("Test registry.count", () => {
-	const broker = new ServiceBroker({ internalActions: false });
+	const broker = new ServiceBroker({ internalServices: false });
 	const registry = broker.serviceRegistry;
 
 	let service = {
@@ -549,7 +549,7 @@ describe("Test registry.count", () => {
 
 describe("Test registry.getServiceList", () => {
 	describe("Test without internal actions", () => {
-		const broker = new ServiceBroker({ internalActions: false });
+		const broker = new ServiceBroker({ internalServices: false });
 		const registry = broker.serviceRegistry;
 
 		let service = {
@@ -638,7 +638,7 @@ describe("Test registry.getServiceList", () => {
 	});
 
 	describe("Test with internal actions", () => {
-		const broker = new ServiceBroker({ internalActions: true });
+		const broker = new ServiceBroker({ internalServices: true });
 		const registry = broker.serviceRegistry;
 
 		it("should returns the internal list", () => {
@@ -651,7 +651,7 @@ describe("Test registry.getServiceList", () => {
 });
 
 describe("Test registry.getActionList", () => {
-	const broker = new ServiceBroker({ internalActions: true });
+	const broker = new ServiceBroker({ internalServices: true });
 	const registry = broker.serviceRegistry;
 
 	let service = {

--- a/test/unit/service.spec.js
+++ b/test/unit/service.spec.js
@@ -53,7 +53,7 @@ describe("Test Service constructor", () => {
 });
 
 describe("Test action creation", () => {
-	let broker = new ServiceBroker({ internalActions: false });
+	let broker = new ServiceBroker({ internalServices: false });
 
 	let schema = {
 		name: "posts",
@@ -113,7 +113,7 @@ describe("Test action creation", () => {
 });
 
 describe("Test events creation", () => {
-	let broker = new ServiceBroker({ internalActions: false });
+	let broker = new ServiceBroker({ internalServices: false });
 
 	let schema = {
 		name: "posts",
@@ -157,7 +157,7 @@ describe("Test events creation", () => {
 });
 
 describe("Test methods creation", () => {
-	let broker = new ServiceBroker({ internalActions: false });
+	let broker = new ServiceBroker({ internalServices: false });
 
 	let schema = {
 		name: "posts",
@@ -190,7 +190,7 @@ describe("Test methods creation", () => {
 });
 
 describe("Test created event handler", () => {
-	let broker = new ServiceBroker({ internalActions: false });
+	let broker = new ServiceBroker({ internalServices: false });
 
 	let schema = {
 		name: "posts",

--- a/test/unit/transit.spec.js
+++ b/test/unit/transit.spec.js
@@ -513,7 +513,7 @@ describe("Test Transit.discoverNodes", () => {
 
 describe("Test Transit.sendNodeInfo", () => {
 
-	const broker = new ServiceBroker({ nodeID: "node1", transporter: new FakeTransporter(), internalActions: false });
+	const broker = new ServiceBroker({ nodeID: "node1", transporter: new FakeTransporter(), internalServices: false });
 	const transit = broker.transit;
 
 	transit.publish = jest.fn();
@@ -622,7 +622,7 @@ describe("Test Transit.deserialize", () => {
 describe("Test Transit node & heartbeat handling", () => {
 
 	describe("Test processNodeInfo", () => {
-		const broker = new ServiceBroker({ nodeID: "node1", transporter: new FakeTransporter(), internalActions: false });
+		const broker = new ServiceBroker({ nodeID: "node1", transporter: new FakeTransporter(), internalServices: false });
 		const transit = broker.transit;
 		broker.registerRemoteService = jest.fn();
 		broker.unregisterServicesByNode = jest.fn();


### PR DESCRIPTION
- The internal $node actions wrapped to a service. It's loaded when `internalService` is true.
- Removed nodeID == null means local node logic from every core modules. If you want to check the given node is local node use `if (nodeID == broker.nodeID)`.
- Changes `$node.list`, ˙$node.services` results (cause of removed nodeID == null).
- renamed `internalActions` to `internalServices` in broker options