### PR TITLE
Hot reload services

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -46,7 +46,7 @@
 			"program": "${workspaceRoot}\\dev\\index.js",
 			"cwd": "${workspaceRoot}",
 			"args": [
-				"dev"
+				"hot"
 			]
 		},
 		{

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,31 @@ The metrics payload contains `remoteCall` and `callerNodeID` properties. The `re
 
 # New
 
+## Hot reload services
+The ServiceBroker supports hot reloading services. If you enable it broker will watch file changes. If you modify service file, broker will reload it on-the-fly.
+[Demo video](https://www.youtube.com/watch?v=l9FsAvje4F4)
+
+> Note: Hot reloading is only working with Moleculer Runner or if you load your services with `broker.loadService` or `broker.loadServices`.
+
+**Usage**
+
+```js
+let broker = new ServiceBroker({
+    logger: console,
+    hotReload: true
+});
+
+broker.loadService("./services/test.service.js");
+```
+
+**Usage with Moleculer Runner**
+
+Turn it on with `--hot` or `-H` flags.
+
+```bash
+$ moleculer-runner --hot ./services/test.service.js
+```
+
 ## Protocol documentation
 Moleculer protocol documentation is available in [docs/PROTOCOL.md](docs/PROTOCOL.md) file.
 

--- a/dev/hot-client.js
+++ b/dev/hot-client.js
@@ -1,0 +1,24 @@
+/* eslint-disable no-console */
+
+"use strict";
+
+let ServiceBroker = require("../src/service-broker");
+
+// Create broker
+let broker = new ServiceBroker({
+	nodeID: "client-" + process.pid,
+	transporter: "NATS",
+	logger: console
+});
+
+broker.start().then(() => {
+
+	setInterval(() => {
+		broker.call("test.hello")
+			.then(res => broker.logger.info("Result:", res))
+			.catch(err => broker.logger.warn(err.message));
+
+
+	}, 1000);
+
+});

--- a/dev/hot.js
+++ b/dev/hot.js
@@ -6,7 +6,6 @@ let ServiceBroker = require("../src/service-broker");
 
 // Create broker
 let broker = new ServiceBroker({
-	namespace: "multi",
 	nodeID: "hot-" + process.pid,
 	transporter: "NATS",
 	logger: console

--- a/dev/hot.js
+++ b/dev/hot.js
@@ -8,11 +8,14 @@ let ServiceBroker = require("../src/service-broker");
 let broker = new ServiceBroker({
 	nodeID: "hot-" + process.pid,
 	transporter: "NATS",
-	logger: console
+	logger: console,
+	//logLevel: "debug",
+	hotReload: true
 });
 
 broker.start().then(() => {
 
+	/*
 	let svc;
 	setTimeout(() => {
 		console.log("Create math service...");
@@ -37,5 +40,10 @@ broker.start().then(() => {
 		broker.destroyService(svc);
 
 	}, 10000);
+	*/
 
+	broker.loadService("./examples/hot.service.js");
+	broker.loadService("./examples/math.service.js");
+
+	broker.repl();
 });

--- a/examples/hot.service.js
+++ b/examples/hot.service.js
@@ -4,7 +4,7 @@ module.exports = {
 	name: "test",
 	actions: {
 		hello() {
-			return "It's awesome!!!";
+			return "Hello Moleculer!!!";
 		}
 	}
 };

--- a/examples/hot.service.js
+++ b/examples/hot.service.js
@@ -4,7 +4,7 @@ module.exports = {
 	name: "test",
 	actions: {
 		hello() {
-			return "Hello Moleculer!";
+			return "It's awesome!!!";
 		}
 	}
 };

--- a/examples/hot.service.js
+++ b/examples/hot.service.js
@@ -1,0 +1,10 @@
+"use strict";
+
+module.exports = {
+	name: "test",
+	actions: {
+		hello() {
+			return "Hello Moleculer!";
+		}
+	}
+};

--- a/index.d.ts
+++ b/index.d.ts
@@ -100,6 +100,7 @@ declare interface BrokerOptions {
 	metricsRate?: Number;
 	statistics?: Boolean;
 	internalServices?: Boolean;
+	hotReload?: Boolean;
 
 	ServiceFactory?: Service;
 	ContextFactory?: Context;
@@ -123,6 +124,8 @@ declare class ServiceBroker {
 	fatal(message: String, err?: Error, needExit?: boolean = true);
 	loadServices(folder?: String, fileMask?: String): Number;
 	loadService(filePath: String): Service;
+	watchService(service: Service);
+	hotReloadService(service: Service): Service;
 	createService(schema: Object): Service;
 	destroyService(service: Service): Promise<any>;
 	registerLocalService(service: Service);

--- a/src/service-registry.js
+++ b/src/service-registry.js
@@ -290,9 +290,10 @@ class ServiceRegistry {
 
 			if (item.count > 0) {
 				const ep = entry.list[0];
-				item.action = _.omit(ep.action, ["handler", "service"]);
+				if (ep)
+					item.action = _.omit(ep.action, ["handler", "service"]);
 			}
-			if (item.action.protected === true) return;
+			if (item.action == null || item.action.protected === true) return;
 
 			if (withEndpoints) {
 				if (item.count > 0) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -29,7 +29,7 @@ let utils = {
 
 	/**
 	 * Get default NodeID (computerName)
-	 * 
+	 *
 	 * @returns
 	 */
 	getNodeID() {
@@ -38,8 +38,8 @@ let utils = {
 
 	/**
 	 * Get list of local IPs
-	 * 
-	 * @returns 
+	 *
+	 * @returns
 	 */
 	getIpList() {
 		const list = [];
@@ -58,7 +58,7 @@ let utils = {
 
 	/**
 	 * Delay for Promises
-	 * 
+	 *
 	 * @param {any} ms
 	 * @returns
 	 */
@@ -69,7 +69,7 @@ let utils = {
 
 	/**
 	 * Check the param is a Promise instance
-	 * 
+	 *
 	 * @param {any} p
 	 * @returns
 	 */
@@ -80,10 +80,10 @@ let utils = {
 
 	/**
 	 * Merge two Service schema
-	 * 
-	 * @param {Object} schema 
-	 * @param {Object} mods 
-	 * @returns 
+	 *
+	 * @param {Object} schema
+	 * @param {Object} mods
+	 * @returns
 	 */
 	mergeSchemas(schema, mods) {
 		function updateProp(propName, target, source) {
@@ -116,6 +116,14 @@ let utils = {
 		});
 
 		return res;
+	},
+
+	clearRequireCache(filename) {
+		Object.keys(require.cache).forEach(function(key) {
+			if (key == filename) {
+				delete require.cache[key];
+			}
+		});
 	}
 
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -119,6 +119,7 @@ let utils = {
 	},
 
 	clearRequireCache(filename) {
+		/* istanbul ignore next */
 		Object.keys(require.cache).forEach(function(key) {
 			if (key == filename) {
 				delete require.cache[key];


### PR DESCRIPTION
The ServiceBroker supports hot reloading services. If you enable it broker will watch file changes. If you modify service file, broker will reload it on-the-fly.
[Demo video](https://www.youtube.com/watch?v=l9FsAvje4F4)

> Note: Hot reloading is only working with Moleculer Runner or if you load your services with `broker.loadService` or `broker.loadServices`.

**Usage**

```js
let broker = new ServiceBroker({
    logger: console,
    hotReload: true
});

broker.loadService("./services/test.service.js");
```

**Usage with Moleculer Runner**

Turn it on with `--hot` or `-H` flags.

```bash
$ moleculer-runner --hot ./services/test.service.js
```