### PR TITLE
Fix bluebird warning

### DIFF
--- a/src/service-broker.js
+++ b/src/service-broker.js
@@ -554,6 +554,8 @@ class ServiceBroker {
 
 				this.logger.info(`Service '${service.name}' is destroyed!`);
 				this.servicesChanged(true);
+
+				return Promise.resolve();
 			});
 	}
 


### PR DESCRIPTION
After hotReload bluebird say: 'Warning: a promise was created in a handler at .../node_modules/moleculer/src/service-broker.js:556:10 but was not returned from it, see http://goo.gl/rRqMUw'