### PR TITLE
Support version on waitForServices

### DIFF
--- a/src/service-broker.js
+++ b/src/service-broker.js
@@ -667,7 +667,12 @@ class ServiceBroker {
 		return new Promise((resolve, reject) => {
 			const check = () => {
 				const count = serviceNames.filter(name => {
-					return this.registry.hasService(name);
+					// Split to version and name if possible
+					const svcMeta = name.split('.');
+					if(svcMeta.length === 2)
+						return this.registry.hasService(svcMeta[1], svcMeta[0].substr(1));
+					else
+						return this.registry.hasService(name);
 				});
 
 				if (count.length == serviceNames.length) {

--- a/src/service-broker.js
+++ b/src/service-broker.js
@@ -661,26 +661,22 @@ class ServiceBroker {
 		if (!Array.isArray(serviceNames))
 			serviceNames = [serviceNames];
 
-		logger.info(`Waiting for service(s) '${serviceNames.join(", ")}'...`);
+		const serviceObjs = serviceNames.map(x => _.isPlainObject(x) ? x : { name: x });
+		logger.info(`Waiting for service(s) '${_.map(serviceObjs, "name").join(", ")}'...`);
 
 		const startTime = Date.now();
 		return new Promise((resolve, reject) => {
 			const check = () => {
-				const count = serviceNames.filter(name => {
-					// Split to version and name if possible
-					const svcMeta = name.split('.');
-					if(svcMeta.length === 2)
-						return this.registry.hasService(svcMeta[1], svcMeta[0].substr(1));
-					else
-						return this.registry.hasService(name);
+				const count = serviceObjs.filter(svcObj => {
+					return this.registry.hasService(svcObj.name, svcObj.version);
 				});
 
-				if (count.length == serviceNames.length) {
-					logger.info(`Service(s) '${serviceNames.join(", ")}' are available.`);
+				if (count.length == serviceObjs.length) {
+					logger.info(`Service(s) '${_.map(serviceObjs, "name").join(", ")}' are available.`);
 					return resolve();
 				}
 
-				logger.debug(`${count.length} of ${serviceNames.length} services are available. Waiting further...`);
+				logger.debug(`${count.length} of ${serviceObjs.length} services are available. Waiting further...`);
 
 				if (timeout && Date.now() - startTime > timeout)
 					return reject(new E.MoleculerServerError("Services waiting is timed out.", 500, "WAITFOR_SERVICES", { services: serviceNames }));

--- a/test/unit/service-broker.spec.js
+++ b/test/unit/service-broker.spec.js
@@ -1094,6 +1094,72 @@ describe("Test broker.waitForServices", () => {
 		return p;
 	});
 
+	it("should wait for service when service is passed as an array of string", () => {
+		let p = broker.waitForServices(["posts"], 10 * 1000, 100).catch(protectReject).then(() => {
+			expect(broker.registry.hasService).toHaveBeenCalledTimes(7);
+			expect(broker.registry.hasService).toHaveBeenLastCalledWith("posts", undefined);
+		});
+
+		setTimeout(() => res = true, 450);
+
+		return p;
+	});
+
+	it("should wait for service when service is passed as an array of object", () => {
+		let p = broker.waitForServices([{ name: "posts" }], 10 * 1000, 100).catch(protectReject).then(() => {
+			expect(broker.registry.hasService).toHaveBeenCalledTimes(8);
+			expect(broker.registry.hasService).toHaveBeenLastCalledWith("posts", undefined);
+		});
+
+		setTimeout(() => res = true, 450);
+
+		return p;
+	});
+
+	it("should wait for service when service is passed as an object", () => {
+		let p = broker.waitForServices({ name: "posts" }, 10 * 1000, 100).catch(protectReject).then(() => {
+			expect(broker.registry.hasService).toHaveBeenCalledTimes(9);
+			expect(broker.registry.hasService).toHaveBeenLastCalledWith("posts", undefined);
+		});
+
+		setTimeout(() => res = true, 450);
+
+		return p;
+	});
+
+	it("should wait for service when service is passed as an array of object with version", () => {
+		let p = broker.waitForServices([{ name: "posts", version: 1 }], 10 * 1000, 100).catch(protectReject).then(() => {
+			expect(broker.registry.hasService).toHaveBeenCalledTimes(10);
+			expect(broker.registry.hasService).toHaveBeenLastCalledWith("posts", 1);
+		});
+
+		setTimeout(() => res = true, 450);
+
+		return p;
+	});
+
+	it("should wait for service when service is passed as an array of object with version and unrelated property", () => {
+		let p = broker.waitForServices([{ name: "posts", version: 1, meta: true }], 10 * 1000, 100).catch(protectReject).then(() => {
+			expect(broker.registry.hasService).toHaveBeenCalledTimes(11);
+			expect(broker.registry.hasService).toHaveBeenLastCalledWith("posts", 1);
+		});
+
+		setTimeout(() => res = true, 450);
+
+		return p;
+	});
+
+	it("should wait for service when service is passed as an array of object without name", () => {
+		let p = broker.waitForServices([{ svcName: "posts", version: 1, meta: true }], 10 * 1000, 100).catch(protectReject).then(() => {
+			expect(broker.registry.hasService).toHaveBeenCalledTimes(12);
+			expect(broker.registry.hasService).toHaveBeenLastCalledWith(undefined, 1);
+		});
+
+		setTimeout(() => res = true, 450);
+
+		return p;
+	});
+
 	it("should reject if timed out", () => {
 		broker.registry.hasService.mockClear();
 		res = false;


### PR DESCRIPTION
If a service has version ```waitForServices()``` function was not able to find the service because the version is undefined when passed to ```registry.hasService()```

it checks if the version can be extracted from the service names with format 
```
v1.accounts
v2.users
```