### PR TITLE
Service dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 # New
 
 ## Service dependencies [#102](https://github.com/ice-services/moleculer/issues/102)
-The `Service` schema has a new `dependencies` property. You can use it to wait other services before `started` handler would be called.
+The `Service` schema has a new `dependencies` property. You can wait other dependent services when service is starting. So you don't need to call `waitForServices` in `started` any more.
 
 ```js
 module.exports = {
@@ -23,12 +23,14 @@ module.exports = {
   ....
 }
 ```
-The `started` service handler will be called if the `likes`, `users` and `comments` services is registered (on the local or remote nodes).
+The `started` service handler is called after the `likes`, `users` and `comments` services are registered (on the local or remote nodes).
+
+> Services can wait for each others, it's not a problem.
 
 # Changes
 
 ## The `waitForServices` method supports service versions [#112](https://github.com/ice-services/moleculer/issues/112)
-By [@imatefx](https://github.com/imatefx), the `waitForServices` broker & service methods supports versioned services. If you want to define version in a dependency, use the following formats:
+By [@imatefx](https://github.com/imatefx), the `waitForServices` broker & service methods support versioned services. If you want to define version in a dependency, use the following formats:
 
 ```js
 module.exports = {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,43 @@
+<a name="0.11.2"></a>
+# [0.11.2](https://github.com/ice-services/moleculer/compare/v0.11.1...v0.11.2) (2017-xx-xx)
+
+# New
+
+## Service dependencies [#102](https://github.com/ice-services/moleculer/issues/102)
+The `Service` schema has a new `dependencies` property. You can use it to wait other services before `started` handler would be called.
+
+```js
+module.exports = {
+  name: "posts",
+  settings: {
+      $dependencyTimeout: 30000 // Default: 0 - no timeout
+  },
+  dependencies: [
+      "likes", // shorthand w/o version
+      { name: "users", version: 2 }, // with numeric version
+      { name: "comments", version: "staging" } // with string version
+  ],
+  started() {
+      this.logger.info("Service started after the dependent services available.");
+  }
+  ....
+}
+```
+The `started` service handler will be called if the `likes`, `users` and `comments` services is registered (on the local or remote nodes).
+
+# Changes
+
+## The `waitForServices` method supports service versions [#112](https://github.com/ice-services/moleculer/issues/112)
+By [@imatefx](https://github.com/imatefx), the `waitForServices` broker & service methods supports versioned services. If you want to define version in a dependency, use the following formats:
+
+```js
+module.exports = {
+    name: "test",
+    dependencies: { name: "users", version: 2 }
+};
+```
+
+--------------------------------------------------
 <a name="0.11.1"></a>
 # [0.11.1](https://github.com/ice-services/moleculer/compare/v0.11.0...v0.11.1) (2017-09-27)
 

--- a/dev/dep.js
+++ b/dev/dep.js
@@ -19,7 +19,7 @@ broker.createService({
 		$dependencyTimeout: 0
 	},
 	dependencies: [
-		{ name: "test", version: 2 },
+		//{ name: "test", version: 2 },
 		"math"
 	],
 	started() {

--- a/dev/dep.js
+++ b/dev/dep.js
@@ -1,0 +1,34 @@
+/* eslint-disable no-console */
+
+"use strict";
+
+let ServiceBroker = require("../src/service-broker");
+
+// Create broker
+let broker = new ServiceBroker({
+	nodeID: "dep-" + process.pid,
+	transporter: "NATS",
+	logger: console,
+	//logLevel: "debug",
+	//hotReload: true
+});
+
+broker.createService({
+	name: "dep-test",
+	settings: {
+		$dependencyTimeout: 0
+	},
+	dependencies: [
+		{ name: "test", version: 2 },
+		"math"
+	],
+	started() {
+		this.logger.info("!!! SERVICE STARTED !!!");
+	}
+});
+
+broker.start().then(() => {
+	broker.logger.info("!!! BROKER STARTED !!!");
+
+	//broker.repl();
+});

--- a/dev/dep2.js
+++ b/dev/dep2.js
@@ -1,0 +1,29 @@
+/* eslint-disable no-console */
+
+"use strict";
+
+let ServiceBroker = require("../src/service-broker");
+
+// Create broker
+let broker = new ServiceBroker({
+	nodeID: "dep-" + process.pid,
+	transporter: "NATS",
+	logger: console,
+	//logLevel: "debug",
+	//hotReload: true
+});
+
+broker.createService({
+	name: "test",
+	version: 2,
+	dependencies: ["dep-test"],
+	started() {
+		this.logger.info("!!! SERVICE STARTED !!!");
+	}
+});
+
+broker.start().then(() => {
+	broker.logger.info("!!! BROKER STARTED !!!");
+
+	//broker.repl();
+});

--- a/src/service-broker.js
+++ b/src/service-broker.js
@@ -293,6 +293,10 @@ class ServiceBroker {
 	start() {
 		return Promise.resolve()
 			.then(() => {
+				if (this.transit)
+					return this.transit.connect();
+			})
+			.then(() => {
 				// Call service `started` handlers
 				return Promise.all(this.services.map(svc => svc.started.call(svc)));
 			})
@@ -300,10 +304,6 @@ class ServiceBroker {
 				/* istanbul ignore next */
 				this.logger.error("Unable to start all services.", err);
 				return Promise.reject(err);
-			})
-			.then(() => {
-				if (this.transit)
-					return this.transit.connect();
 			})
 			.then(() => {
 				this.logger.info(`ServiceBroker with ${this.services.length} service(s) is started successfully.`);
@@ -319,7 +319,7 @@ class ServiceBroker {
 	stop() {
 		return Promise.resolve()
 			.then(() => {
-				// Call service `started` handlers
+				// Call service `stopped` handlers
 				return Promise.all(this.services.map(svc => svc.stopped.call(svc)));
 			})
 			.catch(err => {

--- a/src/service.js
+++ b/src/service.js
@@ -114,11 +114,16 @@ class Service {
 				event.handler = function(payload, sender, eventName) {
 					if (isFunction(handler)) {
 						const p = handler.apply(self, [payload, sender, eventName]);
+
+						// Handle async-await returns
 						if (utils.isPromise(p))
 							p.catch(err => self.logger.error(err));
+
 					} else if (Array.isArray(handler)) {
 						handler.forEach(fn => {
 							const p = fn.apply(self, [payload, sender, eventName]);
+
+							// Handle async-await returns
 							if (utils.isPromise(p))
 								p.catch(err => self.logger.error(err));
 						});
@@ -137,7 +142,7 @@ class Service {
 
 			forIn(schema.methods, (method, name) => {
 				/* istanbul ignore next */
-				if (["name", "version", "settings", "metadata", "schema", "broker", "actions", "logger", "created", "started", "stopped"].indexOf(name) != -1) {
+				if (["name", "version", "settings", "metadata", "dependencies", "schema", "broker", "actions", "logger", "created", "started", "stopped"].indexOf(name) != -1) {
 					throw new ServiceSchemaError(`Invalid method name '${name}' in '${this.name}' service!`);
 				}
 				this[name] = method.bind(this);

--- a/src/utils.js
+++ b/src/utils.js
@@ -108,7 +108,7 @@ let utils = {
 			} else if (["created", "started", "stopped"].indexOf(key) !== -1) {
 				// Concat lifecycle event handlers
 				res[key] = _.compact(_.flatten([res[key], mods[key]]));
-			} else if (["mixins"].indexOf(key) !== -1) {
+			} else if (["mixins", "dependencies"].indexOf(key) !== -1) {
 				// Concat mixins
 				res[key] = _.compact(_.flatten([mods[key], res[key]]));
 			} else

--- a/test/integration/service-deps.spec.js
+++ b/test/integration/service-deps.spec.js
@@ -1,0 +1,41 @@
+const ServiceBroker = require("../../src/service-broker");
+
+describe("Test Service dependencies", () => {
+
+	const broker1 = new ServiceBroker({ nodeID: "node-1", transporter: "fake" });
+	const broker2 = new ServiceBroker({ nodeID: "node-2", transporter: "fake" });
+
+	const startedMain = jest.fn();
+	broker1.createService({
+		name: "main",
+		dependencies: ["test", "math"],
+		started: startedMain
+	});
+
+	const startedMath = jest.fn();
+	broker2.createService({
+		name: "math",
+		dependencies: { name: "test" },
+		started: startedMath
+	});
+
+	broker2.createService({
+		name: "test"
+	});
+
+	broker1.start();
+
+	it("should not call main started", () => {
+		return broker1.Promise.delay(500).then(() => {
+			expect(startedMain).toHaveBeenCalledTimes(0);
+		});
+	});
+
+	it("should call main started if broker2.starts", () => {
+		return broker2.start().delay(1000).then(() => {
+			expect(startedMain).toHaveBeenCalledTimes(1);
+			expect(startedMath).toHaveBeenCalledTimes(1);
+		});
+	});
+
+});

--- a/test/integration/service-mixins.spec.js
+++ b/test/integration/service-mixins.spec.js
@@ -93,6 +93,8 @@ describe("Test Service mixins", () => {
 			e: "Susan"
 		},
 
+		dependencies: "math",
+
 		actions: {
 			gamma() {
 				return "From mixin2L1";
@@ -124,6 +126,11 @@ describe("Test Service mixins", () => {
 		mixins: [
 			mixin1L1,
 			mixin2L1
+		],
+
+		dependencies: [
+			"posts",
+			{ name: "users", version: 2 }
 		],
 
 		settings: {
@@ -158,6 +165,7 @@ describe("Test Service mixins", () => {
 	let broker = new ServiceBroker();
 
 	let svc = broker.createService(mainSchema);
+	svc.waitForServices = jest.fn(() => Promise.resolve());
 
 	// console.log(svc.schema);
 
@@ -187,6 +195,16 @@ describe("Test Service mixins", () => {
 			e: "Susan",
 			f: "Bill"
 		});
+	});
+
+	it("should merge dependencies", () => {
+		expect(svc.schema.dependencies).toEqual([
+			"posts",
+			{ name: "users", version: 2 },
+			"math"
+		]);
+		expect(svc.waitForServices).toHaveBeenCalledTimes(1);
+		expect(svc.waitForServices).toHaveBeenCalledWith(["posts", { name: "users", version: 2 }, "math"], 0);
 	});
 
 	it("should merge metadata", () => {

--- a/test/integration/service.lifecycle.spec.js
+++ b/test/integration/service.lifecycle.spec.js
@@ -70,8 +70,10 @@ describe("Test Service handlers after broker.call", () => {
 	});
 
 	it("should called created & started handler", () => {
-		expect(createdHandler).toHaveBeenCalledTimes(1);
-		expect(startedHandler).toHaveBeenCalledTimes(1);
+		return broker.Promise.delay(100).then(() => {
+			expect(createdHandler).toHaveBeenCalledTimes(1);
+			expect(startedHandler).toHaveBeenCalledTimes(1);
+		});
 	});
 
 	it("should called event handler", () => {

--- a/test/unit/service-broker.spec.js
+++ b/test/unit/service-broker.spec.js
@@ -486,8 +486,8 @@ describe("Test broker.start", () => {
 		});
 
 		it("should call started of services", () => {
+			expect(broker.transit.connect).toHaveBeenCalledTimes(1);
 			expect(schema.started).toHaveBeenCalledTimes(1);
-			expect(broker.transit.connect).toHaveBeenCalledTimes(0);
 		});
 	});
 

--- a/test/unit/utils.spec.js
+++ b/test/unit/utils.spec.js
@@ -52,6 +52,11 @@ describe("Test mergeSchemas", () => {
 				]
 			},
 
+			dependencies: [
+				"posts",
+				"users"
+			],
+
 			metadata: {
 				a: "a",
 				b: 33,
@@ -102,6 +107,8 @@ describe("Test mergeSchemas", () => {
 					"third"
 				]
 			},
+
+			dependencies: "math",
 
 			metadata: {
 				a: "aaa",
@@ -168,6 +175,7 @@ describe("Test mergeSchemas", () => {
 				res: "test"
 			}
 		});
+		expect(res.dependencies).toEqual(["math", "posts", "users"]);
 
 		expect(res.actions.get).toBe(origSchema.actions.get);
 		expect(res.actions.find).toBe(newSchema.actions.find);


### PR DESCRIPTION
Issue: #102 

The `Service` schema has a new `dependencies` property. You can use it to wait other services before `started` handler would be called.

```js
module.exports = {
  name: "posts",
  settings: {
      $dependencyTimeout: 30000 // Default: 0 - no timeout
  },
  dependencies: [
      "likes", // shorthand w/o version
      { name: "users", version: 2 }, // with numeric version
      { name: "comments", version: "staging" } // with string version
  ],
  started() {
      this.logger.info("Service started after the dependent services available.");
  }
  ....
}
```
The `started` service handler will be called if the `likes`, `users` and `comments` services is registered (on the local or remote nodes).