### PR TITLE
Strategy resolver

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
 			"type": "node",
 			"request": "launch",
 			"name": "Launch dev",
-			"program": "${workspaceRoot}\\dev\\client.js",
+			"program": "${workspaceRoot}\\dev\\dev.js",
 			"cwd": "${workspaceRoot}",
 			"args": [
 				""

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+<a name="0.11.9"></a>
+# [0.11.9](https://github.com/ice-services/moleculer/compare/v0.11.8...v0.11.9) (2018-xx-xx)
+
+# Changes
+- ServiceBroker can resolve the `strategy` as a string. 
+```js
+let broker = new ServiceBroker({
+    registry: {
+        strategy: "Random"
+        // strategy: "RoundRobin"
+    }
+});
+```
+
+You can set it via env variables too if you are using the Moleculer Runner:
+```sh
+$ REGISTRY_STRATEGY=random
+```
+
 --------------------------------------------------
 <a name="0.11.8"></a>
 # [0.11.8](https://github.com/ice-services/moleculer/compare/v0.11.7...v0.11.8) (2017-12-15)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 <a name="0.11.9"></a>
 # [0.11.9](https://github.com/ice-services/moleculer/compare/v0.11.8...v0.11.9) (2018-xx-xx)
 
-# Changes
-- ServiceBroker can resolve the `strategy` as a string. 
+# New
+
+## Strategy resolver
+
+ServiceBroker can resolve the `strategy` from a string.
 ```js
 let broker = new ServiceBroker({
     registry: {
@@ -12,10 +15,14 @@ let broker = new ServiceBroker({
 });
 ```
 
-You can set it via env variables too if you are using the Moleculer Runner:
+You can set it via env variables as well, if you are using the Moleculer Runner:
 ```sh
 $ REGISTRY_STRATEGY=random
 ```
+
+# Fixes
+- fixed hot reloading after broken service files by @askuzminov ([#155](https://github.com/ice-services/moleculer/pull/155))
+
 
 --------------------------------------------------
 <a name="0.11.8"></a>

--- a/dev/dev.js
+++ b/dev/dev.js
@@ -4,10 +4,14 @@
 
 let fs = require("fs");
 let ServiceBroker = require("../src/service-broker");
+let S = require("../src/strategies");
 
 let broker = new ServiceBroker({
 	logger: true,
 	logLevel: "debug",
+	registry: {
+		strategy: "Random"
+	},
 	transporter: {
 		type: "NATS",
 		options: {
@@ -46,16 +50,4 @@ broker.createService({
 });
 
 broker.start()
-	// Without meta  - no cache
-	.then(() => broker.call("math.add", { a: 5, b: 3 }).then(res => broker.logger.info("[No cache] 5 + 3 =", res)))
-	// Without meta  - cache
-	.then(() => broker.call("math.add", { a: 5, b: 3 }).then(res => broker.logger.info("[CACHED] 5 + 3 =", res)))
-
-	// With meta  - no cache
-	.then(() => broker.call("math.add", { a: 5, b: 3 }, { meta: { c: 2 }}).then(res => broker.logger.info("[No cache] 5 + 3 + 2 =", res)))
-	// With meta  - cache
-	.then(() => broker.call("math.add", { a: 5, b: 3 }, { meta: { c: 2 }}).then(res => broker.logger.info("[CACHED] 5 + 3 + 2 =", res)))
-	// With meta  - no cache
-	.then(() => broker.call("math.add", { a: 5, b: 3 }, { meta: { c: 4 }}).then(res => broker.logger.info("[No cache] 5 + 3 + 4 =", res)))
-
 	.then(() => broker.repl());

--- a/src/registry/registry.js
+++ b/src/registry/registry.js
@@ -35,7 +35,9 @@ class Registry {
 		this.opts = Object.assign({}, broker.options.registry);
 		this.opts.circuitBreaker = broker.options.circuitBreaker || {};
 
-		this.StrategyFactory = this.opts.strategy || RoundRobinStrategy;
+		this.StrategyFactory = broker._resolveStrategy(this.opts.strategy);
+
+		this.logger.info("Strategy:", this.StrategyFactory.name);
 
 		this.nodes = new NodeCatalog(this, broker);
 		this.services = new ServiceCatalog(this, broker);

--- a/src/service-broker.js
+++ b/src/service-broker.js
@@ -303,14 +303,14 @@ class ServiceBroker {
 				throw new E.MoleculerServerError(`Invalid strategy type '${opt}'.`, null, "INVALID_STRATEGY_TYPE", { type: opt });
 
 		} else if (_.isObject(opt)) {
-			let SerializerClass = this.getModuleClass(Strategies, opt.type);
+			let SerializerClass = this.getModuleClass(Strategies, opt.type || "RoundRobin");
 			if (SerializerClass)
 				return SerializerClass;
 			else
 				throw new E.MoleculerServerError(`Invalid strategy type '${opt.type}'.`, null, "INVALID_STRATEGY_TYPE", { type: opt.type });
 		}
 
-		return new Strategies.RoundRobin;
+		return Strategies.RoundRobin;
 	}
 
 	/**

--- a/test/unit/service-broker.spec.js
+++ b/test/unit/service-broker.spec.js
@@ -423,6 +423,48 @@ describe("Test option resolvers", () => {
 		});
 
 	});
+
+	describe("Test _resolveStrategy", () => {
+
+		let broker = new ServiceBroker();
+
+		it("should resolve null from undefined", () => {
+			let Strategy = broker._resolveStrategy();
+			expect(Strategy).toBe(Strategies.RoundRobin);
+		});
+
+		it("should resolve RoundRobinStrategy from obj without type", () => {
+			let Strategy = broker._resolveStrategy({});
+			expect(Strategy).toBe(Strategies.RoundRobin);
+		});
+
+		it("should resolve RoundRobinStrategy from obj", () => {
+			let Strategy = broker._resolveStrategy({ type: "random" });
+			expect(Strategy).toBe(Strategies.Random);
+
+			Strategy = broker._resolveStrategy({ type: "Random" });
+			expect(Strategy).toBe(Strategies.Random);
+		});
+
+		it("should resolve RandomStrategy from string with 'random' and 'Random' type", () => {
+			let Strategy = broker._resolveStrategy("random");
+			expect(Strategy).toBe(Strategies.Random);
+
+			Strategy = broker._resolveStrategy("Random");
+			expect(Strategy).toBe(Strategies.Random);
+		});
+
+		it("should throw error if type if not correct", () => {
+			expect(() => {
+				broker._resolveStrategy("xyz");
+			}).toThrowError(MoleculerError);
+
+			expect(() => {
+				broker._resolveStrategy({ type: "xyz" });
+			}).toThrowError(MoleculerError);
+		});
+
+	});
 });
 
 describe("Test broker.start", () => {


### PR DESCRIPTION
Base issue: #157 

## Strategy resolver

ServiceBroker can resolve the `strategy` from a string.
```js
let broker = new ServiceBroker({
    registry: {
        strategy: "Random"
        // strategy: "RoundRobin"
    }
});
```

You can set it via env variables as well, if you are using the Moleculer Runner:
```sh
$ REGISTRY_STRATEGY=random
```