### PR TITLE
Moleculer Runner loads env file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,21 @@ You can set it via env variables as well, if you are using the Moleculer Runner:
 $ REGISTRY_STRATEGY=random
 ```
 
+## Load env files in Moleculer Runner [#158](https://github.com/ice-services/moleculer/issues/158)
+Moleculer runner can load `.env` file at starting. There are two new cli options to load env file:
+
+* `-e, --env` - Load envorinment variables from the '.env' file from the current folder.
+* `-E, --envfile <filename>` - Load envorinment variables from the specified file.
+ 
+**Example**
+```sh
+# Load the default .env file from current directory
+$ moleculer-runner --env 
+
+# Load the specified .my-env file
+$ moleculer-runner --envfile .my-env
+```
+
 # Fixes
 - fixed hot reloading after broken service files by @askuzminov ([#155](https://github.com/ice-services/moleculer/pull/155))
 

--- a/bin/moleculer-runner.js
+++ b/bin/moleculer-runner.js
@@ -28,8 +28,8 @@ let logger;
  * 		-H, --hot  			- Hot reload services if changed
  * 		-r, --repl  		- After broker started, switch to REPL mode
  * 		-s , --silent 		- Silent mode. Disable logger, no console messages.
- * 		--env 				- Load envorinment variables from the '.env' file from the current folder.
- * 		--envfile 			- Load envorinment variables from the specified file.
+ * 		-e, --env 			- Load envorinment variables from the '.env' file from the current folder.
+ * 		-E, --envfile 		- Load envorinment variables from the specified file.
  */
 function processFlags() {
 	Args

--- a/bin/moleculer-runner.js
+++ b/bin/moleculer-runner.js
@@ -28,13 +28,17 @@ let logger;
  * 		-H, --hot  			- Hot reload services if changed
  * 		-r, --repl  		- After broker started, switch to REPL mode
  * 		-s , --silent 		- Silent mode. Disable logger, no console messages.
+ * 		--env 				- Load envorinment variables from the '.env' file from the current folder.
+ * 		--envfile 			- Load envorinment variables from the specified file.
  */
 function processFlags() {
 	Args
 		.option("config", "Load the configuration from a file")
 		.option("repl", "Start REPL mode", false)
 		.option(["H", "hot"], "Hot reload services if changed", false)
-		.option("silent", "Silent mode. No logger", false);
+		.option("silent", "Silent mode. No logger", false)
+		.option("env", "Load .env file from the current directory")
+		.option("envfile", "Load a specified .env file");
 
 	flags = Args.parse(process.argv, {
 		mri: {
@@ -42,14 +46,34 @@ function processFlags() {
 				c: "config",
 				r: "repl",
 				H: "hot",
-				s: "silent"
+				s: "silent",
+				e: "env",
+				E: "envfile"
 			},
-			boolean: ["repl", "silent", "hot"],
-			string: ["config"]
+			boolean: ["repl", "silent", "hot", "env"],
+			string: ["config", "envfile"]
 		}
 	});
 
 	servicePaths = Args.sub;
+}
+
+/**
+ * Load environment variables from '.env' file
+ */
+function loadEnvFile() {
+	if (flags.env || flags.envfile) {
+		try {
+			const dotenv = require("dotenv");
+
+			if (flags.envfile)
+				dotenv.config({ path: flags.envfile });
+			else
+				dotenv.config();
+		} catch(err) {
+			throw new Error("The 'dotenv' package is missing! Please install it with 'npm install dotenv --save' command.");
+		}
+	}
 }
 
 /**
@@ -264,6 +288,7 @@ function startBroker() {
  */
 Promise.resolve()
 	.then(processFlags)
+	.then(loadEnvFile)
 	.then(loadConfigFile)
 	.then(mergeOptions)
 	.then(startBroker)

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "benchmarkify": "2.1.0",
     "bunyan": "1.8.12",
     "coveralls": "3.0.0",
+    "dotenv": "4.0.0",
     "eslint": "4.14.0",
     "eslint-plugin-node": "5.2.1",
     "eslint-plugin-promise": "3.6.0",


### PR DESCRIPTION
## Load env files in Moleculer Runner [#158](https://github.com/ice-services/moleculer/issues/158)
Moleculer runner can load `.env` file at starting. There are two new cli options to load env file:

* `-e, --env` - Load envorinment variables from the '.env' file from the current folder.
* `-E, --envfile <filename>` - Load envorinment variables from the specified file.
 
**Example**
```sh
# Load the default .env file from current directory
$ moleculer-runner --env 

# Load the specified .my-env file
$ moleculer-runner --envfile .my-env
```