### PR TITLE
apply logger fix to 8.x and above (broken in 9.0)

### DIFF
--- a/src/logger.js
+++ b/src/logger.js
@@ -81,7 +81,7 @@ module.exports = {
 
 			let method = baseLogger[type];
 
-			if (baseLogger === console && process.versions.node.split(".")[0] == 8 && type === "debug")
+			if (baseLogger === console && process.versions.node.split(".")[0] >= 8 && type === "debug")
 				method = null;
 
 			if (!method) {


### PR DESCRIPTION
`debug` logging is broken in node 9.0, apply the same fix used for 8.x