### PR TITLE
Add listener for SIGTERM

### DIFF
--- a/src/service-broker.js
+++ b/src/service-broker.js
@@ -208,6 +208,7 @@ class ServiceBroker {
 		process.on("beforeExit", this._closeFn);
 		process.on("exit", this._closeFn);
 		process.on("SIGINT", this._closeFn);
+		process.on("SIGTERM", this._closeFn);
 	}
 
 	getModuleClass(obj, name) {
@@ -404,6 +405,7 @@ class ServiceBroker {
 				process.removeListener("beforeExit", this._closeFn);
 				process.removeListener("exit", this._closeFn);
 				process.removeListener("SIGINT", this._closeFn);
+				process.removeListener("SIGTERM", this._closeFn);
 			});
 	}
 


### PR DESCRIPTION
Some hosted services (like AWS) send SIGTERM before shutdown of a service. This is then followed after a timeout by SIGKILL to force the termination. Since SIGINT is not sent on these services a graceful shutdown is not possible and leads to nodes not deregistering their services.